### PR TITLE
Add time based retention and attach

### DIFF
--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -28,9 +28,11 @@
 
 -type offset() :: non_neg_integer().
 -type epoch() :: non_neg_integer().
+-type milliseconds() :: non_neg_integer().
 -type tail_info() :: {offset(), empty | {epoch(), offset()}}.
 -type offset_spec() :: first | last | next | {abs, offset()} | offset().
--type retention_spec() :: {max_bytes, non_neg_integer()}.
+-type retention_spec() :: {max_bytes, non_neg_integer()} |
+                          {max_age, milliseconds()}.
 
 -export_type([
               state/0,

--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -30,7 +30,13 @@
 -type epoch() :: non_neg_integer().
 -type milliseconds() :: non_neg_integer().
 -type tail_info() :: {offset(), empty | {epoch(), offset()}}.
--type offset_spec() :: first | last | next | {abs, offset()} | offset().
+-type offset_spec() :: first |
+                       last |
+                       next |
+                       {abs, offset()} |
+                       offset() |
+                       {timestamp, milliseconds()}.
+
 -type retention_spec() :: {max_bytes, non_neg_integer()} |
                           {max_age, milliseconds()}.
 

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -6,7 +6,7 @@
 -define(MAGIC, 5).
 %% format version
 -define(VERSION, 0).
--define(HEADER_SIZE, 31).
+-define(HEADER_SIZE, 39).
 
 -define(SUP, osiris_server_sup).
 
@@ -377,6 +377,7 @@ parse_chunk(<<?MAGIC:4/unsigned,
               ?VERSION:4/unsigned,
               _NumEntries:16/unsigned,
               _NumRecords:32/unsigned,
+               _Timestamp:64/signed,
                 _Epoch:64/unsigned,
               FirstOffset:64/unsigned,
               _Crc:32/integer,
@@ -393,7 +394,8 @@ parse_chunk(<<?MAGIC:4/unsigned,
               ?VERSION:4/unsigned,
               _NumEntries:16/unsigned,
               _NumRecords:32/unsigned,
-                _Epoch:64/unsigned,
+              _Timestamp:64/signed,
+              _Epoch:64/unsigned,
               FirstOffset:64/unsigned,
               _Crc:32/integer,
               Size:32/unsigned,

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -30,7 +30,7 @@
          code_change/3]).
 
 %% holds static or rarely changing fields
--record(cfg, {
+-record(cfg, {name :: string(),
               leader_pid :: pid(),
               directory :: file:filename(),
               port :: non_neg_integer(),
@@ -122,7 +122,8 @@ get_port(Server) ->
 %%                     {stop, Reason}
 %% @end
 %%--------------------------------------------------------------------
-init(#{leader_pid := LeaderPid,
+init(#{name := Name,
+       leader_pid := LeaderPid,
        external_ref := ExtRef} = Config) ->
     {ok, {Min, Max}} = application:get_env(port_range),
     {Port, LSock} = open_tcp_port(Min, Max),
@@ -179,7 +180,8 @@ init(#{leader_pid := LeaderPid,
     atomics:put(ORef, 1, -1),
     EvtFmt = maps:get(event_formatter, Config, undefined),
     ?INFO("osiris_replica:init/1: next offset ~b", [NextOffset]),
-    {ok, #?MODULE{cfg = #cfg{leader_pid = LeaderPid,
+    {ok, #?MODULE{cfg = #cfg{name = Name,
+                             leader_pid = LeaderPid,
                              directory = Dir,
                              port = Port,
                              listening_socket = LSock,
@@ -237,9 +239,11 @@ handle_call(get_port, _From, #?MODULE{cfg = #cfg{port = Port}} = State) ->
     {reply, Port, State};
 handle_call(get_reader_context, _From,
             #?MODULE{cfg = #cfg{offset_ref = ORef,
+                                name = Name,
                                 directory = Dir},
                      committed_offset = COffs} = State) ->
     Reply = #{dir => Dir,
+              name => Name,
               committed_offset => COffs,
               offset_ref => ORef},
     {reply, Reply, State}.

--- a/src/osiris_retention.erl
+++ b/src/osiris_retention.erl
@@ -56,8 +56,7 @@ handle_call(_Request, _From, State) ->
 %%                                  {noreply, State, Timeout} |
 %%                                  {stop, Reason, State}
 handle_cast({eval, Dir, Specs}, State) ->
-    [ok = osiris_log:evaluate_retention(Dir, Spec)
-     || Spec <- Specs],
+    ok = osiris_log:evaluate_retention(Dir, Specs),
     {noreply, State}.
 
 %% @spec handle_info(Info, State) -> {noreply, State} |

--- a/src/osiris_util.erl
+++ b/src/osiris_util.erl
@@ -2,7 +2,8 @@
 
 -export([validate_base64uri/1,
          to_base64uri/1,
-         id/1]).
+         id/1,
+         lists_find/2]).
 
 -define(BASE64_URI_CHARS,
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -33,4 +34,17 @@ to_base64uri(Str) when is_list(Str) ->
 
 -spec id(term()) -> term().
 id(X) -> X.
+
+-spec lists_find(fun ((term()) -> boolean()), list()) ->
+    {ok, term()} | not_found.
+lists_find(_Pred, []) ->
+    not_found;
+lists_find(Pred, [Item | Rem]) ->
+    case Pred(Item) of
+        true ->
+            {ok, Item};
+        false ->
+            lists_find(Pred, Rem)
+    end.
+
 

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -250,10 +250,12 @@ handle_commands([{cast, {ack, ReplicaNode, Offset}} | Rem],
     handle_commands(Rem, State0#?MODULE{replica_state = ReplicaState}, Acc);
 handle_commands([{call, From, get_reader_context} | Rem],
                 #?MODULE{cfg = #cfg{offset_ref = ORef,
+                                    name = Name,
                                     directory = Dir},
                          committed_offset = COffs} = State,
                 {Records, Replies, Corrs}) ->
     Reply = {reply, From, #{dir => Dir,
+                            name => Name,
                             committed_offset => max(0, COffs),
                             offset_ref => ORef}},
     handle_commands(Rem, State, {Records, [Reply | Replies], Corrs});


### PR DESCRIPTION
Adds a server generated posix timestamp to the chunk format and uses this to implement time based retention and reader attach.

This change breaks the binary format.