### PR TITLE
osiris.hrl: Add domain to logged messages

### DIFF
--- a/src/osiris.hrl
+++ b/src/osiris.hrl
@@ -21,7 +21,8 @@
                                                                     ?FUNCTION_NAME,
                                                                     ?FUNCTION_ARITY},
                                                             file => ?FILE,
-                                                            line => ?LINE}),
+                                                            line => ?LINE,
+                                                            domain => [osiris]}),
        ok).
 
 -define(C_NUM_LOG_FIELDS, 3).


### PR DESCRIPTION
The domain is `[osiris]`. It allows users of Osiris to filter log messages emitted by this application.