### PR TITLE
Export list of all tracked offsets & new counters

### DIFF
--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -12,6 +12,7 @@
 -export([write/4,
          write_tracking/3,
          read_tracking/2,
+         read_tracking/1,
          fetch_writer_seq/2,
          init_reader/2,
          register_offset_listener/2,
@@ -119,6 +120,10 @@ write_tracking(Pid, TrackingId, Offset) ->
 -spec read_tracking(pid(), binary()) -> offset() | undefined.
 read_tracking(Pid, TrackingId) ->
     osiris_writer:read_tracking(Pid, TrackingId).
+
+-spec read_tracking(pid()) -> #{binary() => offset()} | undefined.
+read_tracking(Pid) ->
+    osiris_writer:read_tracking(Pid).
 
 -spec fetch_writer_seq(pid(), binary()) ->
                           non_neg_integer() | undefined.

--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -152,17 +152,17 @@ fetch_writer_seq(Pid, WriterId)
 %% @returns `{ok, state()} | {error, Error}' when error can be
 %% `{offset_out_of_range, empty | {From :: offset(), To :: offset()}}'
 %% @end
--spec init_reader(pid(), offset_spec(), atom()) ->
+-spec init_reader(pid(), offset_spec(), osiris_log:counter_spec()) ->
                      {ok, osiris_log:state()} |
                      {error,
                       {offset_out_of_range, empty | {offset(), offset()}}} |
                      {error, {invalid_last_offset_epoch, offset(), offset()}}.
-init_reader(Pid, OffsetSpec, Tag)
+init_reader(Pid, OffsetSpec, {_, _} = CounterSpec)
     when is_pid(Pid) andalso node(Pid) =:= node() ->
     ?DEBUG("osiris: initialising reader. Spec: ~w", [OffsetSpec]),
-    {ok, #{reference := Ref} = Ctx0} = gen:call(Pid, '$gen_call', get_reader_context),
-    CntId = {?MODULE, Ref, Tag, Pid},
-    Ctx = Ctx0#{counter_spec => {CntId, []}},
+    {ok, Ctx0} = gen:call(Pid, '$gen_call', get_reader_context),
+    % CntId = {?MODULE, Ref, Tag, Pid},
+    Ctx = Ctx0#{counter_spec => CounterSpec},
     osiris_log:init_offset_reader(OffsetSpec, Ctx).
 
 -spec register_offset_listener(pid(), offset()) -> ok.

--- a/src/osiris.hrl
+++ b/src/osiris.hrl
@@ -30,7 +30,7 @@
                                                             domain => [osiris]}),
        ok).
 
--define(C_NUM_LOG_FIELDS, 3).
+-define(C_NUM_LOG_FIELDS, 4).
 
 -define(MAGIC, 5).
 %% chunk format version

--- a/src/osiris_counters.erl
+++ b/src/osiris_counters.erl
@@ -11,7 +11,8 @@
          new/2,
          fetch/1,
          overview/0,
-         delete/1]).
+         delete/1,
+         delete_all/1]).
 
 %% holds static or rarely changing fields
 -record(cfg, {}).
@@ -47,6 +48,12 @@ fetch(Name) ->
 -spec delete(term()) -> ok.
 delete(Name) ->
     true = ets:delete(?MODULE, Name),
+    ok.
+
+-spec delete_all(term()) -> ok.
+delete_all(Name) ->
+    Match = {{'_', Name},'_', '_'},
+    true = ets:match_delete(?MODULE, Match),
     ok.
 
 -spec overview() -> #{name() => #{atom() => non_neg_integer()}}.

--- a/src/osiris_counters.erl
+++ b/src/osiris_counters.erl
@@ -11,8 +11,8 @@
          new/2,
          fetch/1,
          overview/0,
-         delete/1,
-         delete_all/1]).
+         delete/1
+        ]).
 
 %% holds static or rarely changing fields
 -record(cfg, {}).
@@ -48,12 +48,6 @@ fetch(Name) ->
 -spec delete(term()) -> ok.
 delete(Name) ->
     true = ets:delete(?MODULE, Name),
-    ok.
-
--spec delete_all(term()) -> ok.
-delete_all(Name) ->
-    Match = {{'_', Name},'_', '_'},
-    true = ets:match_delete(?MODULE, Match),
     ok.
 
 -spec overview() -> #{name() => #{atom() => non_neg_integer()}}.

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -319,6 +319,7 @@
 -type epoch() :: osiris:epoch().
 -type range() :: empty | {From :: offset(), To :: offset()}.
 -type tracking_id() :: binary(). %% max 255 bytes
+-type counter_spec() :: {Tag :: term(), Fields :: [atom()]}.
 -type chunk_type() ::
     ?CHNK_USER |
     ?CHNK_TRK_DELTA |
@@ -329,7 +330,7 @@
     #{dir := file:filename(),
       epoch => non_neg_integer(),
       max_segment_size => non_neg_integer(),
-      counter_spec => {Tag :: term(), Fields :: [atom()]}}.
+      counter_spec => counter_spec()}.
 -type record() :: {offset(), iodata()}.
 -type offset_spec() :: osiris:offset_spec().
 -type retention_spec() :: osiris:retention_spec().
@@ -396,9 +397,8 @@
 
 -export_type([state/0,
               range/0,
-              config/0]).
-
-              % record/0,
+              config/0,
+              counter_spec/0]).
 
 -spec directory(osiris:config() | list()) -> file:filename().
 directory(#{name := Name, dir := Dir}) ->
@@ -1488,7 +1488,7 @@ update_retention(Retention,
     State.
 
 -spec evaluate_retention(file:filename(), [retention_spec()]) ->
-                            range().
+    {range(), non_neg_integer()}.
 evaluate_retention(Dir, Specs) ->
     SegInfos0 = build_log_overview(Dir),
     SegInfos = evaluate_retention0(SegInfos0, Specs),

--- a/src/osiris_server_sup.erl
+++ b/src/osiris_server_sup.erl
@@ -39,12 +39,11 @@ stop_child(Node, CName) ->
             ok
     end.
 
-delete_child(Node, #{name := CName, reference := Ref} = Config) ->
+delete_child(Node, #{name := CName} = Config) ->
     try
         case supervisor:get_childspec({?MODULE, Node}, CName) of
             {ok, _} ->
                 stop_child(Node, CName),
-                rpc:call(Node, osiris_counters, delete_all, [Ref]),
                 rpc:call(Node, osiris_log, delete_directory, [Config]);
             {error, not_found} ->
                 ok

--- a/src/osiris_server_sup.erl
+++ b/src/osiris_server_sup.erl
@@ -39,11 +39,12 @@ stop_child(Node, CName) ->
             ok
     end.
 
-delete_child(Node, #{name := CName} = Config) ->
+delete_child(Node, #{name := CName, reference := Ref} = Config) ->
     try
         case supervisor:get_childspec({?MODULE, Node}, CName) of
             {ok, _} ->
                 stop_child(Node, CName),
+                rpc:call(Node, osiris_counters, delete_all, [Ref]),
                 rpc:call(Node, osiris_log, delete_directory, [Config]);
             {error, not_found} ->
                 ok

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -15,7 +15,6 @@
 -export([start_link/1,
          start/1,
          overview/1,
-         init_data_reader/2,
          init_data_reader/3,
          register_data_listener/2,
          ack/2,
@@ -31,8 +30,9 @@
          stop/1,
          delete/1]).
 
--define(ADD_COUNTER_FIELDS, [committed_offset]).
+-define(ADD_COUNTER_FIELDS, [committed_offset, readers]).
 -define(C_COMMITTED_OFFSET, ?C_NUM_LOG_FIELDS + 1).
+-define(C_READERS, ?C_NUM_LOG_FIELDS + 2).
 
 %% primary osiris process
 %% batch writes incoming data
@@ -87,10 +87,6 @@ start_link(Config) ->
 overview(Pid) when node(Pid) == node() ->
     #{dir := Dir} = gen_batch_server:call(Pid, get_reader_context),
     {ok, osiris_log:overview(Dir)}.
-
-init_data_reader(Pid, TailInfo) when node(Pid) == node() ->
-    Ctx = gen_batch_server:call(Pid, get_reader_context),
-    osiris_log:init_data_reader(TailInfo, Ctx).
 
 init_data_reader(Pid, TailInfo, {_, _} = CounterSpec)
   when node(Pid) == node() ->
@@ -372,8 +368,10 @@ handle_command({cast, {ack, ReplicaNode, Offset}},
 handle_command({call, From, get_reader_context},
                {#?MODULE{cfg =
                              #cfg{offset_ref = ORef,
+                                  reference = Ref,
                                   name = Name,
-                                  directory = Dir},
+                                  directory = Dir,
+                                  counter = CntRef},
                          committed_offset = COffs} =
                     State,
                 Records,
@@ -387,7 +385,10 @@ handle_command({call, From, get_reader_context},
          #{dir => Dir,
            name => Name,
            committed_offset => max(0, COffs),
-           offset_ref => ORef}},
+           offset_ref => ORef,
+           reference => Ref,
+           readers_counter_fun => fun(Inc) -> counters:add(CntRef, ?C_READERS, Inc) end
+          }},
     {State, Records, [Reply | Replies], Corrs, Trk, Wrt, Dupes};
 handle_command({call, From, {query_writers, QueryFun}},
                {State, Records, Replies0, Corrs, Trk, Wrt, Dupes}) ->

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -22,6 +22,7 @@
          write/5,
          write_tracking/3,
          read_tracking/2,
+         read_tracking/1,
          query_writers/2,
          init/1,
          handle_batch/2,
@@ -125,6 +126,9 @@ write_tracking(Pid, TrackingId, Offset)
 
 read_tracking(Pid, TrackingId) ->
     gen_batch_server:call(Pid, {read_tracking, TrackingId}).
+
+read_tracking(Pid) ->
+    gen_batch_server:call(Pid, read_tracking).
 
 query_writers(Pid, QueryFun) ->
     gen_batch_server:call(Pid, {query_writers, QueryFun}).
@@ -317,6 +321,11 @@ handle_command({call, From, {read_tracking, TrackingId}},
     Tracking = osiris_log:tracking(State#?MODULE.log),
     Replies =
         [{reply, From, maps:get(TrackingId, Tracking, undefined)} | Replies0],
+    {State, Records, Replies, Corrs, Trk, Wrt, Dupes};
+handle_command({call, From, read_tracking},
+               {State, Records, Replies0, Corrs, Trk, Wrt, Dupes}) ->
+    Tracking = osiris_log:tracking(State#?MODULE.log),
+    Replies = [{reply, From, Tracking} | Replies0],
     {State, Records, Replies, Corrs, Trk, Wrt, Dupes};
 handle_command({cast, {register_data_listener, Pid, Offset}},
                {#?MODULE{data_listeners = Listeners} = State0,

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -221,12 +221,12 @@ single_node_offset_listener(Config) ->
           replica_nodes => []},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
     {error, {offset_out_of_range, empty}} =
-        osiris:init_reader(Leader, {abs, 0}, 'test'),
+        osiris:init_reader(Leader, {abs, 0}, {test, []}),
     osiris:register_offset_listener(Leader, 0),
     ok = osiris:write(Leader, undefined, 42, <<"mah-data">>),
     receive
         {osiris_offset, _Name, 0} ->
-            {ok, Log0} = osiris:init_reader(Leader, {abs, 0}, 'test'),
+            {ok, Log0} = osiris:init_reader(Leader, {abs, 0}, {test, []}),
             {[{0, <<"mah-data">>}], Log} = osiris_log:read_chunk_parsed(Log0),
             {end_of_stream, _} = osiris_log:read_chunk_parsed(Log),
             ok
@@ -245,7 +245,7 @@ single_node_reader_counters(Config) ->
           leader_node => node(),
           replica_nodes => []},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
-    {ok, Log0} = osiris:init_reader(Leader, next, 'test'),
+    {ok, Log0} = osiris:init_reader(Leader, next, {test, []}),
     Overview = osiris_counters:overview(),
     ?assertEqual(1, maps:get(readers, maps:get({'osiris_writer', Name}, Overview))),
     {ok, Log1} = osiris_writer:init_data_reader(Leader, {0, empty}, {'test_data', []}),
@@ -270,7 +270,7 @@ cluster_reader_counters(Config) ->
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
     Overview0 = osiris_counters:overview(),
     ?assertEqual(2, maps:get(readers, maps:get({'osiris_writer', Name}, Overview0))),
-    {ok, Log0} = osiris:init_reader(Leader, next, 'test'),
+    {ok, Log0} = osiris:init_reader(Leader, next, {test, []}),
     Overview1 = osiris_counters:overview(),
     ?assertEqual(3, maps:get(readers, maps:get({'osiris_writer', Name}, Overview1))),
     {ok, Log1} = osiris_writer:init_data_reader(Leader, {0, empty}, {'test_data', []}),
@@ -292,7 +292,7 @@ single_node_offset_listener2(Config) ->
           leader_node => node(),
           replica_nodes => []},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
-    {ok, Log0} = osiris:init_reader(Leader, next, 'test'),
+    {ok, Log0} = osiris:init_reader(Leader, next, {test, []}),
     Next = osiris_log:next_offset(Log0),
     ok = osiris:write(Leader, undefined, 42, <<"mah-data">>),
     wait_for_written([42]),
@@ -320,7 +320,7 @@ cluster_offset_listener(Config) ->
           leader_node => node(),
           replica_nodes => Replicas},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
-    {ok, Log0} = osiris:init_reader(Leader, 0, 'test'),
+    {ok, Log0} = osiris:init_reader(Leader, 0, {test, []}),
     osiris:register_offset_listener(Leader, 0),
     ok = osiris:write(Leader, undefined, 42, <<"mah-data">>),
     receive
@@ -356,7 +356,7 @@ replica_offset_listener(Config) ->
     R = hd(ReplicaPids),
     _ = spawn(node(R),
               fun() ->
-                 {ok, Log0} = osiris:init_reader(R, 0, 'test'),
+                 {ok, Log0} = osiris:init_reader(R, 0, {test, []}),
                  osiris:register_offset_listener(R, 0),
                  receive
                      {osiris_offset, _Name, O} when O > -1 ->

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -52,7 +52,9 @@ all_tests() ->
      single_node_deduplication_2,
      cluster_minority_deduplication,
      cluster_deduplication,
-     writers_retention].
+     writers_retention,
+     single_node_reader_counters,
+     cluster_reader_counters].
 
 -define(BIN_SIZE, 800).
 
@@ -219,12 +221,12 @@ single_node_offset_listener(Config) ->
           replica_nodes => []},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
     {error, {offset_out_of_range, empty}} =
-        osiris:init_reader(Leader, {abs, 0}),
+        osiris:init_reader(Leader, {abs, 0}, 'test'),
     osiris:register_offset_listener(Leader, 0),
     ok = osiris:write(Leader, undefined, 42, <<"mah-data">>),
     receive
         {osiris_offset, _Name, 0} ->
-            {ok, Log0} = osiris:init_reader(Leader, {abs, 0}),
+            {ok, Log0} = osiris:init_reader(Leader, {abs, 0}, 'test'),
             {[{0, <<"mah-data">>}], Log} = osiris_log:read_chunk_parsed(Log0),
             {end_of_stream, _} = osiris_log:read_chunk_parsed(Log),
             ok
@@ -235,6 +237,52 @@ single_node_offset_listener(Config) ->
     flush(),
     ok.
 
+single_node_reader_counters(Config) ->
+    Name = ?config(cluster_name, Config),
+    Conf0 =
+        #{name => Name,
+          epoch => 1,
+          leader_node => node(),
+          replica_nodes => []},
+    {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
+    {ok, Log0} = osiris:init_reader(Leader, next, 'test'),
+    Overview = osiris_counters:overview(),
+    ?assertEqual(1, maps:get(readers, maps:get({'osiris_writer', Name}, Overview))),
+    {ok, Log1} = osiris_writer:init_data_reader(Leader, {0, empty}, {'test_data', []}),
+    Overview1 = osiris_counters:overview(),
+    ?assertEqual(2, maps:get(readers, maps:get({'osiris_writer', Name}, Overview1))),
+    osiris_log:close(Log0),
+    Overview2 = osiris_counters:overview(),
+    ?assertEqual(1, maps:get(readers, maps:get({'osiris_writer', Name}, Overview2))),
+    osiris_log:close(Log1),
+    Overview3 = osiris_counters:overview(),
+    ?assertEqual(0, maps:get(readers, maps:get({'osiris_writer', Name}, Overview3))).
+
+cluster_reader_counters(Config) ->
+    PrivDir = ?config(data_dir, Config),
+    Name = ?config(cluster_name, Config),
+    [_ | Replicas] = [start_child_node(N, PrivDir) || N <- [s1, s2, s3]],
+    Conf0 =
+        #{name => Name,
+          epoch => 1,
+          leader_node => node(),
+          replica_nodes => Replicas},
+    {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
+    Overview0 = osiris_counters:overview(),
+    ?assertEqual(2, maps:get(readers, maps:get({'osiris_writer', Name}, Overview0))),
+    {ok, Log0} = osiris:init_reader(Leader, next, 'test'),
+    Overview1 = osiris_counters:overview(),
+    ?assertEqual(3, maps:get(readers, maps:get({'osiris_writer', Name}, Overview1))),
+    {ok, Log1} = osiris_writer:init_data_reader(Leader, {0, empty}, {'test_data', []}),
+    Overview2 = osiris_counters:overview(),
+    ?assertEqual(4, maps:get(readers, maps:get({'osiris_writer', Name}, Overview2))),
+    osiris_log:close(Log0),
+    Overview3 = osiris_counters:overview(),
+    ?assertEqual(3, maps:get(readers, maps:get({'osiris_writer', Name}, Overview3))),
+    osiris_log:close(Log1),
+    Overview4 = osiris_counters:overview(),
+    ?assertEqual(2, maps:get(readers, maps:get({'osiris_writer', Name}, Overview4))).
+
 single_node_offset_listener2(Config) ->
     %% writes before registering
     Name = ?config(cluster_name, Config),
@@ -244,7 +292,7 @@ single_node_offset_listener2(Config) ->
           leader_node => node(),
           replica_nodes => []},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
-    {ok, Log0} = osiris:init_reader(Leader, next),
+    {ok, Log0} = osiris:init_reader(Leader, next, 'test'),
     Next = osiris_log:next_offset(Log0),
     ok = osiris:write(Leader, undefined, 42, <<"mah-data">>),
     wait_for_written([42]),
@@ -272,7 +320,7 @@ cluster_offset_listener(Config) ->
           leader_node => node(),
           replica_nodes => Replicas},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
-    {ok, Log0} = osiris:init_reader(Leader, 0),
+    {ok, Log0} = osiris:init_reader(Leader, 0, 'test'),
     osiris:register_offset_listener(Leader, 0),
     ok = osiris:write(Leader, undefined, 42, <<"mah-data">>),
     receive
@@ -308,7 +356,7 @@ replica_offset_listener(Config) ->
     R = hd(ReplicaPids),
     _ = spawn(node(R),
               fun() ->
-                 {ok, Log0} = osiris:init_reader(R, 0),
+                 {ok, Log0} = osiris:init_reader(R, 0, 'test'),
                  osiris:register_offset_listener(R, 0),
                  receive
                      {osiris_offset, _Name, O} when O > -1 ->
@@ -353,7 +401,7 @@ read_validate_single_node(Config) ->
     ct:pal("writing ~b", [Num]),
     write_n(Leader, Num, #{}),
     % stop_profile(Config),
-    {ok, Log0} = osiris_writer:init_data_reader(Leader, {0, empty}),
+    {ok, Log0} = osiris_writer:init_data_reader(Leader, {0, empty}, {'test', []}),
 
     ct:pal("~w counters ~p", [node(), osiris_counters:overview()]),
 
@@ -414,7 +462,7 @@ read_validate(Config) ->
      end
      || N <- Replicas],
 
-    {ok, Log0} = osiris_writer:init_data_reader(Leader, {0, empty}),
+    {ok, Log0} = osiris_writer:init_data_reader(Leader, {0, empty}, {'test', []}),
     {_, _} = timer:tc(fun() -> validate_read(Num, Log0) end),
 
     %% test reading on slave
@@ -422,7 +470,7 @@ read_validate(Config) ->
     Self = self(),
     _ = spawn(node(R),
               fun() ->
-                 {ok, RLog0} = osiris_writer:init_data_reader(R, {0, empty}),
+                 {ok, RLog0} = osiris_writer:init_data_reader(R, {0, empty}, {'test', []}),
                  {_, _} = timer:tc(fun() -> validate_read(Num, RLog0) end),
                  Self ! validate_read_done
               end),
@@ -1188,7 +1236,7 @@ search_paths() ->
 validate_log(Leader, Exp) when is_pid(Leader) ->
     case node(Leader) == node() of
         true ->
-            {ok, Log0} = osiris_writer:init_data_reader(Leader, {0, empty}),
+            {ok, Log0} = osiris_writer:init_data_reader(Leader, {0, empty}, {'test', []}),
             validate_log(Log0, Exp);
         false ->
             ok = rpc:call(node(Leader), ?MODULE, ?FUNCTION_NAME, [Leader, Exp])

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -91,7 +91,7 @@ init_per_testcase(TestCase, Config) ->
       #{dir => Dir,
         name => atom_to_list(TestCase),
         epoch => 1,
-        readers_count => fun(_) -> ok end}},
+        readers_counter_fun => fun(_) -> ok end}},
      {dir, Dir}
      | Config].
 

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -90,7 +90,8 @@ init_per_testcase(TestCase, Config) ->
      {osiris_conf,
       #{dir => Dir,
         name => atom_to_list(TestCase),
-        epoch => 1}},
+        epoch => 1,
+        readers_count => fun(_) -> ok end}},
      {dir, Dir}
      | Config].
 


### PR DESCRIPTION
The new counters include:
* Number of segments
* readers: replica readers, offset readers and data readers. The sum of these provides an estimate of the open files on each osiris node. Applications can customise using a tag the counter for each time of offset/data reader they might use.
