### PR TITLE
Offset readers handle missing segments

### DIFF
--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -139,9 +139,13 @@ init(#{name := Name,
     Dir = osiris_log:directory(Config),
     process_flag(trap_exit, true),
     process_flag(message_queue_data, off_heap),
-    ORef = atomics:new(1, [{signed, true}]),
+    ORef = atomics:new(2, [{signed, true}]),
     CntName = {?MODULE, ExtRef},
     Log = osiris_log:init(Config#{dir => Dir,
+                                  first_offset_fun =>
+                                  fun (Fst) ->
+                                          atomics:put(ORef, 2, Fst)
+                                  end,
                                   counter_spec =>
                                       {CntName, ?ADD_COUNTER_FIELDS}}),
     CntRef = osiris_log:counters_ref(Log),


### PR DESCRIPTION
When retention "takes-over" an offset reader it is possible that a
segment later than the one currently being read is deleted. When the
offset reader reaches the end of it's current segment and finds the next
segment missing it gets stuck and things it has reached the end of the
stream. This change expands the use of the atomic value for the commit
index to also include the first index in the stream which the reader can
query to ensure it correctly can work out what the next available
segment is.