### PR TITLE
Add support for tracking types

### DIFF
--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -40,6 +40,7 @@
 
 -type mfarg() :: {module(), atom(), list()}.
 -type offset() :: non_neg_integer().
+-type tracking_type() :: osiris_log:tracking_type().
 -type epoch() :: non_neg_integer().
 -type milliseconds() :: non_neg_integer().
 -type tail_info() :: {NextOffset :: offset(),
@@ -118,7 +119,7 @@ write(Pid, WriterId, Corr, Data) ->
 write_tracking(Pid, TrackingId, Offset) ->
     osiris_writer:write_tracking(Pid, TrackingId, Offset).
 
--spec read_tracking(pid(), binary()) -> offset() | undefined.
+-spec read_tracking(pid(), binary()) -> {tracking_type(), offset()} | undefined.
 read_tracking(Pid, TrackingId) ->
     osiris_writer:read_tracking(Pid, TrackingId).
 

--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -123,7 +123,7 @@ write_tracking(Pid, TrackingId, Offset) ->
 read_tracking(Pid, TrackingId) ->
     osiris_writer:read_tracking(Pid, TrackingId).
 
--spec read_tracking(pid()) -> #{binary() => offset()} | undefined.
+-spec read_tracking(pid()) -> #{binary() => {tracking_type(), offset()}} | undefined.
 read_tracking(Pid) ->
     osiris_writer:read_tracking(Pid).
 

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -120,7 +120,7 @@ write_tracking(Pid, TrackingId, Offset)
          andalso is_binary(TrackingId)
          andalso byte_size(TrackingId) =< 255
          andalso is_integer(Offset) ->
-    gen_batch_server:cast(Pid, {write_tracking, TrackingId, Offset}).
+    gen_batch_server:cast(Pid, {write_tracking, TrackingId, offset, Offset}).
 
 read_tracking(Pid, TrackingId) ->
     gen_batch_server:call(Pid, {read_tracking, TrackingId}).
@@ -318,9 +318,9 @@ handle_command({cast, {write, Pid, WriterId, Corr, R}},
              Wrt,
              [{ChId, Pid, WriterId, Corr} | Dupes]}
     end;
-handle_command({cast, {write_tracking, TrackingId, Offset}},
+handle_command({cast, {write_tracking, TrackingId, TrackingType, TrackingData}},
                {State, Records, Replies, Corrs, Trk0, Wrt, Dupes}) ->
-    Trk = Trk0#{TrackingId => Offset},
+    Trk = Trk0#{TrackingId => {TrackingType, TrackingData}},
     {State, Records, Replies, Corrs, Trk, Wrt, Dupes};
 handle_command({call, From, {read_tracking, TrackingId}},
                {State, Records, Replies0, Corrs, Trk, Wrt, Dupes}) ->

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -967,10 +967,10 @@ tracking(Config) ->
     %% batch which due to batch reversal isn't possible. This should be ok
     %% given the use case for reading tracking
     timer:sleep(100),
-    ?assertEqual(0, osiris:read_tracking(Leader, TrackId)),
+    ?assertEqual({offset, 0}, osiris:read_tracking(Leader, TrackId)),
     ok = osiris:write_tracking(Leader, TrackId, 1),
     timer:sleep(100),
-    ?assertEqual(1, osiris:read_tracking(Leader, TrackId)),
+    ?assertEqual({offset, 1}, osiris:read_tracking(Leader, TrackId)),
 
     ok.
 
@@ -998,7 +998,7 @@ tracking_many(Config) ->
     ok = osiris:write_tracking(Leader, TrackId, 2),
     ok = osiris:write_tracking(Leader, TrackId, 3),
     timer:sleep(250),
-    ?assertEqual(3, osiris:read_tracking(Leader, TrackId)),
+    ?assertEqual({offset, 3}, osiris:read_tracking(Leader, TrackId)),
     ok.
 
 tracking_all(Config) ->
@@ -1026,9 +1026,9 @@ tracking_all(Config) ->
     ok = osiris:write_tracking(Leader, TrackId2, 1),
     ok = osiris:write_tracking(Leader, TrackId3, 2),
     timer:sleep(250),
-    ?assertEqual(#{TrackId1 => 0,
-                   TrackId2 => 1,
-                   TrackId3 => 2}, osiris:read_tracking(Leader)),
+    ?assertEqual(#{TrackId1 => {offset, 0},
+                   TrackId2 => {offset, 1},
+                   TrackId3 => {offset, 2}}, osiris:read_tracking(Leader)),
     ok.
 
 tracking_retention(Config) ->
@@ -1054,7 +1054,7 @@ tracking_retention(Config) ->
     timer:sleep(1000),
     %% tracking id should be gone
     ?assertEqual(undefined, osiris:read_tracking(Leader, TrkId)),
-    ?assertEqual(Num, osiris:read_tracking(Leader, TrkId2)),
+    ?assertEqual({offset, Num}, osiris:read_tracking(Leader, TrkId2)),
     ok.
 
 single_node_deduplication(Config) ->

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -596,7 +596,7 @@ accept_chunk(Config) ->
     FConf = Conf#{dir => ?config(follower1_dir, Config)},
     L0 = osiris_log:init(LConf),
     %% write an entry with just tracking
-    L1 = osiris_log:write_tracking(#{<<"id1">> => 1}, delta, L0),
+    L1 = osiris_log:write_tracking(#{<<"id1">> => {offset, 1}}, delta, L0),
     timer:sleep(100),
 
     Now = 12345,
@@ -619,7 +619,7 @@ accept_chunk(Config) ->
     osiris_log:close(R2),
     osiris_log:close(F2),
     FL0 = osiris_log:init(FConf),
-    ?assertMatch(#{<<"id1">> := 1}, osiris_log:tracking(FL0)),
+    ?assertMatch(#{<<"id1">> := {offset, 1}}, osiris_log:tracking(FL0)),
     ?assertMatch(#{<<"w1">> := {_, Now, 1}}, osiris_log:writers(FL0)),
     osiris_log:close(FL0),
     ok.
@@ -781,15 +781,15 @@ offset_tracking(Config) ->
     Conf = ?config(osiris_conf, Config),
     S0 = osiris_log:init(Conf),
     ?assertEqual(0, osiris_log:next_offset(S0)),
-    S1 = osiris_log:write_tracking(#{<<"id1">> => 0}, delta,
+    S1 = osiris_log:write_tracking(#{<<"id1">> => {offset, 0}}, delta,
                                    osiris_log:write([<<"hi">>], S0)),
     ?assertEqual(2, osiris_log:next_offset(S1)),
-    ?assertMatch(#{<<"id1">> := 0}, osiris_log:tracking(S1)),
-    S2 = osiris_log:write_tracking(#{<<"id1">> => 1}, delta, S1),
+    ?assertMatch(#{<<"id1">> := {offset, 0}}, osiris_log:tracking(S1)),
+    S2 = osiris_log:write_tracking(#{<<"id1">> => {offset, 1}}, delta, S1),
     %% test recovery
     osiris_log:close(S2),
     S3 = osiris_log:init(Conf),
-    ?assertMatch(#{<<"id1">> := 1}, osiris_log:tracking(S3)),
+    ?assertMatch(#{<<"id1">> := {offset, 1}}, osiris_log:tracking(S3)),
     osiris_log:close(S3),
     ok.
 
@@ -811,12 +811,12 @@ offset_tracking_snapshot(Config) ->
                           S00),
     ?assertMatch(#{<<"wid1">> := {_, Now, 2}}, osiris_log:writers(S0)),
     %% write a tracking entry
-    S1 = osiris_log:write_tracking(#{<<"id1">> => 1}, delta, S0),
+    S1 = osiris_log:write_tracking(#{<<"id1">> => {offset, 1}}, delta, S0),
     %% this should create at least two segments
     S2 = seed_log(S1, EpochChunks, Config),
     osiris_log:close(S2),
     S3 = osiris_log:init(Conf),
-    ?assertMatch(#{<<"id1">> := 1}, osiris_log:tracking(S3)),
+    ?assertMatch(#{<<"id1">> := {offset, 1}}, osiris_log:tracking(S3)),
     ?assertMatch(#{<<"wid1">> := {_, Now, 2}}, osiris_log:writers(S3)),
     osiris_log:close(S3),
     ok.


### PR DESCRIPTION
so that the tracking doesn't always need to be an offset but could be
extended to include timestamps or in flight chunk ids (as is needed for
competing reader tracking).