### PR TITLE
Faster implementation of index scanning

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -388,9 +388,9 @@
          fd :: undefined | file:io_device(),
          index_fd :: undefined | file:io_device()}).
 -record(chunk_info,
-        {epoch :: epoch(),
+		{id :: offset(),
          timestamp :: non_neg_integer(),
-         id :: offset(),
+		 epoch :: epoch(),
          num :: non_neg_integer()
          }).
 -record(seg_info,
@@ -865,7 +865,7 @@ init_data_reader({StartOffset, PrevEO}, #{dir := Dir,
                             %% epoch?
                             {ok, Fd} = file:open(PrevSeg, [raw, binary, read]),
                             %% TODO: next offset needs to be a chunk offset
-                            {_, FilePos} = scan_index(PrevIdxFile, Fd, PrevO),
+                            {_, FilePos} = scan_idx(PrevIdxFile, PrevO),
                             {ok, FilePos} = file:position(Fd, FilePos),
                             case file:read(Fd, ?HEADER_SIZE_B) of
                                 {ok,
@@ -915,7 +915,8 @@ init_data_reader_from_segment(#{dir := Dir, name := Name} = Config,
                               NextOffs, CounterFun) ->
     {ok, Fd} = file:open(StartSegment, [raw, binary, read]),
     %% TODO: next offset needs to be a chunk offset
-    {_, FilePos} = scan_index(IndexFile, Fd, NextOffs),
+	{ok, IdxFd} = open_index_read(IndexFile),
+    {_, FilePos} = scan_idx(IdxFd, NextOffs),
     {ok, _Pos} = file:position(Fd, FilePos),
     Cnt = make_counter(Config),
     counters:put(Cnt, ?C_OFFSET, NextOffs - 1),
@@ -1026,8 +1027,9 @@ init_offset_reader(OffsetSpec,
         {_, #seg_info{file = StartSegment, index = IndexFile}} ->
             try
                 {ok, Fd} = open(StartSegment, [raw, binary, read]),
+				IdxFd = open_index_read(IndexFile),
                 {ChOffs, FilePos} =
-                    case scan_index(IndexFile, Fd, StartOffset) of
+                    case scan_idx(IdxFd, StartOffset) of
                         eof ->
                             {StartOffset, 0};
                         enoent ->
@@ -1291,69 +1293,6 @@ header_info(Fd, Pos) ->
        _Reserved:32>>} =
         file:read(Fd, ?HEADER_SIZE_B),
     {ChType, Offset, Epoch, Num, Size, TSize}.
-
-scan_index(IdxFile, SegFd, Offs) when is_list(IdxFile) ->
-    case file:open(IdxFile, [read, raw, binary, read_ahead]) of
-        {ok, Fd} ->
-            case file:read(Fd, ?IDX_HEADER_SIZE) of
-                {ok, ?IDX_HEADER} ->
-                    scan_index(file:read(Fd, ?INDEX_RECORD_SIZE_B * 2),
-                               Fd,
-                               SegFd,
-                               Offs);
-                eof ->
-                    eof;
-                {error, Posix} ->
-                    Posix
-            end;
-        {error, Posix} ->
-            Posix
-    end.
-
-scan_index(eof, IdxFd, _Fd, 0) ->
-    ok = file:close(IdxFd),
-    %% if the index is empty do we really know the offset will be next
-    %% this relies on us always reducing the Offset to within the log range
-    {0, ?LOG_HEADER_SIZE};
-scan_index(eof, IdxFd, _Fd, _) ->
-    ok = file:close(IdxFd),
-    eof;
-scan_index({ok,
-            <<O:64/unsigned, _T:64/signed, E:64/unsigned, Pos:32/unsigned>>},
-           IdxFd,
-           Fd,
-           Offset) ->
-    ok = file:close(IdxFd),
-    {_ChType, O, E, Num, _, _} = header_info(Fd, Pos),
-    case Offset >= O andalso Offset < O + Num of
-        true ->
-            {O, Pos};
-        false ->
-            {O + Num, eof}
-    end;
-scan_index({ok,
-            <<O:64/unsigned,
-              _T:64/signed,
-              _E:64/unsigned,
-              Pos:32/unsigned,
-              ONext:64/unsigned,
-              _:64/signed,
-              _:64/unsigned,
-              _:32/unsigned>>},
-           IdxFd,
-           Fd,
-           Offset) ->
-    case Offset >= O andalso Offset < ONext of
-        true ->
-            ok = file:close(IdxFd),
-            {O, Pos};
-        false ->
-            {ok, _} = file:position(IdxFd, {cur, -?INDEX_RECORD_SIZE_B}),
-            scan_index(file:read(IdxFd, ?INDEX_RECORD_SIZE_B * 2),
-                       IdxFd,
-                       Fd,
-                       Offset)
-    end.
 
 parse_records(_Offs, <<>>, Acc) ->
     %% TODO: this could probably be changed to body recursive
@@ -1864,6 +1803,25 @@ open_index_read(File) ->
     %% {ok, ?IDX_HEADER} = file:read(Fd, ?IDX_HEADER_SIZE)
     _ = file:read(Fd, ?IDX_HEADER_SIZE),
     Fd.
+
+scan_idx(Fd, Offset) ->
+    case file:read(Fd, ?INDEX_RECORD_SIZE_B) of
+        {ok,
+         <<ChunkId:64/unsigned,
+           _Timestamp:64/signed,
+           _Epoch:64/unsigned,
+           FilePos:32/unsigned>>} ->
+            case Offset =< ChunkId of
+                true ->
+                    % ok = file:close(Fd),
+                    {ChunkId, FilePos};
+                false ->
+                    scan_idx(Fd, Offset)
+            end;
+        eof ->
+            ok = file:close(Fd),
+            eof
+    end.
 
 throw_missing({error, enoent}) ->
     throw(missing_file);

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -193,6 +193,7 @@ handle_batch(Commands,
                       committed_offset = COffs0,
                       log = Log0} =
                  State0) ->
+
     %% process commands in reverse order
     case catch lists:foldr(fun handle_command/2,
                            {State0, [], [], #{}, #{}, #{}, []}, Commands)
@@ -218,7 +219,7 @@ handle_batch(Commands,
                 end,
             AllChIds = maps:fold(fun (_, {O, _}, Acc) ->
                                          [O | Acc]
-                                     end, [LastChId], State2#?MODULE.replica_state),
+                                 end, [LastChId], State2#?MODULE.replica_state),
 
             COffs = agreed_commit(AllChIds),
 


### PR DESCRIPTION
We've seen timeouts when connecting consumers to streams that already have data. Even moderate amounts of data, like 0.5GB, could lead to the issue when the client requested to start from an offset towards the tail of the stream. It was because `scan_index` could take almost a minute to find the right offset to attach to so the connection timed out. This is a faster implementation that avoids jumping through the index file back and forth.