### PR TITLE
Add max_segment_size_chunks

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: erlang:22.3.4
+      image: erlang:23
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -12,8 +12,14 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        erlang_version:
+        - "23"
+        - "24"
+
     container:
-      image: erlang:23
+      image: erlang:${{ matrix.erlang_version }}
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ PROJECT_VERSION = 0.1.0
 define PROJECT_ENV
 [
 	{data_dir, "/tmp/osiris"},
-	{port_range, {6000, 6500}}
+	{port_range, {6000, 6500}},
+	{max_segment_size_chunks, 256000}
 ]
 endef
 

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -53,6 +53,8 @@
 -define(TRK_TYPE_OFFSET, 0).
 % maximum size of a segment in bytes
 -define(DEFAULT_MAX_SEGMENT_SIZE_B, 500 * 1000 * 1000).
+% maximum number of chunks per segment
+-define(DEFAULT_MAX_SEGMENT_SIZE_C, 256 * 1000).
 -define(INDEX_RECORD_SIZE_B, 28).
 -define(COUNTER_FIELDS,
         [
@@ -361,7 +363,7 @@
         {directory :: file:filename(),
          name :: string(),
          max_segment_size_bytes = ?DEFAULT_MAX_SEGMENT_SIZE_B :: non_neg_integer(),
-         max_segment_size_chunks :: non_neg_integer(),
+         max_segment_size_chunks = ?DEFAULT_MAX_SEGMENT_SIZE_C :: non_neg_integer(),
          retention = [] :: [osiris:retention_spec()],
          counter :: counters:counters_ref(),
          counter_id :: term(),
@@ -437,7 +439,7 @@ init(#{dir := Dir,
     %% scan directory for segments if in write mode
     MaxSizeBytes =
         maps:get(max_segment_size_bytes, Config, ?DEFAULT_MAX_SEGMENT_SIZE_B),
-    {ok,  MaxSizeChunks} = application:get_env(max_segment_size_chunks),
+    MaxSizeChunks = application:get_env(osiris, max_segment_size_chunks, ?DEFAULT_MAX_SEGMENT_SIZE_C),
     Retention = maps:get(retention, Config, []),
     ?INFO("osiris_log:init/1 max_segment_size_bytes: ~b, max_segment_size_chunks ~b, retention ~w",
           [MaxSizeBytes, MaxSizeChunks, Retention]),

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -838,7 +838,8 @@ retention_add_replica_after(Config) ->
         osiris:start_cluster(Conf0),
     ok = osiris:write(Leader, undefined, 0, <<"first">>),
     write_n(Leader, Num, 0, 1000 * 8, #{}),
-    ok = osiris:write(Leader, undefined, 0, <<"last">>),
+    ok = osiris:write(Leader, undefined, Num + 1, <<"last">>),
+    wait_for_written([Num + 1]),
 
     ct:pal("checking 1", []),
     check_last_entry(Leader, <<"last">>),
@@ -878,7 +879,7 @@ check_last_entry(Pid, Entry) when is_pid(Pid) ->
             ct:pal("checking last entry done ~w", [node(Pid)]),
             ok
     after 10000 ->
-              exit({done_timeout, X})
+              exit({done_timeout, node(X)})
     end,
     ok.
 


### PR DESCRIPTION
We've observed performance degradation when there is lots of chunks in a
single segment. That's because the segment and/or its index need to be
scanned in certain situations and reading chunk by chunk is slow.

For now, it's compile-time setting with a default of 256000. We may
change that into a service configuration property in the future, if
needed.

Fixes: https://github.com/rabbitmq/rabbitmq-streams-project/issues/8