### PR TITLE
Persist retention spec changes

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1483,7 +1483,7 @@ evaluate_retention(Dir, Specs) ->
                                SegInfos = evaluate_retention0(SegInfos0, Specs),
                                {range_from_segment_infos(SegInfos), length(SegInfos)}
                        end),
-    ?DEBUG("~s:~s/~b completed in ~fs", [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, Time/1000000]),
+    ?DEBUG("~s:~s/~b (~w) completed in ~fs", [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, Specs, Time/1000000]),
     Result.
 
 evaluate_retention0(Infos, []) ->

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -210,7 +210,7 @@ handle_batch(Commands,
                                  ?CHNK_USER,
                                  erlang:system_time(millisecond),
                                  Wrt,
-                                 Log0),
+                                 State1#?MODULE.log),
             Log = osiris_log:write_tracking(Trk, delta, Log1),
             State2 =
                 update_pending(ThisBatchOffs, Corrs, State1#?MODULE{log = Log}),


### PR DESCRIPTION
Without this fix, changes to the retention were applied once
(when retention is updated, it is evaluated immediately) but then
forgotten (reset to what was set in osiris_log:init/1).