### PR TITLE
Fix "last offset should find last user chunk" by adding chunk type to index record

### DIFF
--- a/src/osiris.hrl
+++ b/src/osiris.hrl
@@ -43,6 +43,5 @@
 -define(CHNK_USER, 0).
 -define(CHNK_TRK_DELTA, 1).
 -define(CHNK_TRK_SNAPSHOT, 2).
--define(CHNK_WRT_SNAPSHOT, 3).
 
 -define(SUP, osiris_server_sup).

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -51,7 +51,7 @@
 -define(DEFAULT_MAX_SEGMENT_SIZE_B, 500 * 1000 * 1000).
 % maximum number of chunks per segment
 -define(DEFAULT_MAX_SEGMENT_SIZE_C, 256_000).
--define(INDEX_RECORD_SIZE_B, 28).
+-define(INDEX_RECORD_SIZE_B, 29).
 -define(COUNTER_FIELDS,
         [
          %% the last offset (not chunk id) in the log (writers)
@@ -282,8 +282,27 @@
 %% Index format
 %% ============
 %%
-%% Maps each chunk to an offset
-%% | Offset | Timestamp | FileOffset
+%% Each chunk in the segment file maps to an index record in the index file.
+%%
+%% Index record
+%% ------------
+%%
+%%   |0              |1              |2              |3              | Bytes
+%%   |0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7| Bits
+%%   +---------------+---------------+---------------+---------------+
+%%   | Offset                                                        |
+%%   | (8 bytes)                                                     |
+%%   +---------------------------------------------------------------+
+%%   | Timestamp                                                     |
+%%   | (8 bytes)                                                     |
+%%   +---------------------------------------------------------------+
+%%   | Epoch                                                         |
+%%   | (8 bytes)                                                     |
+%%   +---------------------------------------------------------------+
+%%   | File Offset                                                   |
+%%   +---------------+-----------------------------------------------+
+%%   | Chunk Type    |
+%%   +---------------+
 
 -type offset() :: osiris:offset().
 -type epoch() :: osiris:epoch().
@@ -544,14 +563,14 @@ write([_ | _] = Entries,
     %% in order to avoid unnecessary lists rev|trav|ersals
     {ChunkData, NumRecords} =
         make_chunk(Entries, Trailer, ChType, Now, Epoch, Next),
-    write_chunk(ChunkData, Now, Epoch, NumRecords, State0);
+    write_chunk(ChunkData, ChType, Now, Epoch, NumRecords, State0);
 write([], _ChType, _Now, _Writers, State) ->
     State.
 
 -spec accept_chunk(iodata(), state()) -> state().
 accept_chunk([<<?MAGIC:4/unsigned,
                 ?VERSION:4/unsigned,
-                _ChType:8/unsigned,
+                ChType:8/unsigned,
                 _NumEntries:16/unsigned,
                 NumRecords:32/unsigned,
                 Timestamp:64/signed,
@@ -572,7 +591,7 @@ accept_chunk([<<?MAGIC:4/unsigned,
     % true = iolist_size(DataAndTrailer) == (DataSize + TrailerSize),
     %% acceptors do no need to maintain writer state in memory so we pass
     %% the empty map here instead of parsing the trailer
-    case write_chunk(Chunk, Timestamp, Epoch, NumRecords, State0) of
+    case write_chunk(Chunk, ChType, Timestamp, Epoch, NumRecords, State0) of
         full ->
             trigger_retention_eval(
               accept_chunk(Chunk, open_new_segment(State0)));
@@ -647,7 +666,8 @@ chunk_id_index_scan0(Fd, ChunkId) ->
          <<ChunkId:64/unsigned,
            _Timestamp:64/signed,
            Epoch:64/unsigned,
-           FilePos:32/unsigned>>} ->
+           FilePos:32/unsigned,
+           _ChType:8/unsigned>>} ->
             ok = file:close(Fd),
             {ChunkId, Epoch, FilePos, IdxPos};
         {ok, _} ->
@@ -1281,14 +1301,15 @@ build_log_overview0([IdxFile | IdxFiles], Acc0) ->
             ok = file:close(IdxFd),
             build_log_overview0(IdxFiles, Acc0);
         {ok, Pos} ->
-            %% ASSERTION: ensure we don't have rubbish data at end of idex
+            %% ASSERTION: ensure we don't have rubbish data at end of index
             0 = (Pos - ?IDX_HEADER_SIZE) rem ?INDEX_RECORD_SIZE_B,
             case file:read(IdxFd, ?INDEX_RECORD_SIZE_B) of
                 {ok,
                  <<_Offset:64/unsigned,
                    _Timestamp:64/signed,
                    _Epoch:64/unsigned,
-                   LastChunkPos:32/unsigned>>} ->
+                   LastChunkPos:32/unsigned,
+                   _ChType:8/unsigned>>} ->
                     ok = file:close(IdxFd),
                     SegFile = segment_from_index_file(IdxFile),
                     Acc = build_segment_info(SegFile,
@@ -1483,7 +1504,8 @@ last_offset_epoch({ok,
                    <<O:64/unsigned,
                      _T:64/signed,
                      CurEpoch:64/unsigned,
-                     _:32/unsigned>>},
+                     _:32/unsigned,
+                     _ChType:8/unsigned>>},
                   Fd, {CurEpoch, _LastOffs, Acc}) ->
     %% epoch is unchanged
     last_offset_epoch(file:read(Fd, ?INDEX_RECORD_SIZE_B), Fd,
@@ -1492,7 +1514,8 @@ last_offset_epoch({ok,
                    <<O:64/unsigned,
                      _T:64/signed,
                      Epoch:64/unsigned,
-                     _:32/unsigned>>},
+                     _:32/unsigned,
+                     _ChType:8/unsigned>>},
                   Fd, {CurEpoch, LastOffs, Acc})
     when Epoch > CurEpoch ->
     last_offset_epoch(file:read(Fd, ?INDEX_RECORD_SIZE_B), Fd,
@@ -1543,12 +1566,14 @@ make_chunk(Blobs, TData, ChType, Timestamp, Epoch, Next) ->
      NumRecords}.
 
 write_chunk(_Chunk,
+            _ChType,
             _Timestamp,
             _Epoch,
             _NumRecords,
             #?MODULE{fd = undefined} = _State) ->
     full;
 write_chunk(Chunk,
+            ChType,
             Timestamp,
             Epoch,
             NumRecords,
@@ -1571,7 +1596,8 @@ write_chunk(Chunk,
                    <<Next:64/unsigned,
                      Timestamp:64/signed,
                      Epoch:64/unsigned,
-                     Cur:32/unsigned>>),
+                     Cur:32/unsigned,
+                     ChType:8/unsigned>>),
     %% update counters
     counters:put(CntRef, ?C_OFFSET, NextOffset - 1),
     counters:add(CntRef, ?C_CHUNKS, 1),
@@ -1749,7 +1775,8 @@ scan_idx(Fd, Offset, #chunk_info{id = LastChunkInSegmentId, num = LastChunkInSeg
          <<ChunkId:64/unsigned,
            _Timestamp:64/signed,
            _Epoch:64/unsigned,
-           FilePos:32/unsigned>>} ->
+           FilePos:32/unsigned,
+           _ChType:8/unsigned>>} ->
             case Offset < ChunkId of
                 true ->
                     %% offset is lower than the first chunk in this segment
@@ -1777,7 +1804,8 @@ scan_idx(Fd, Offset, PreviousChunk) ->
          <<ChunkId:64/unsigned,
            _Timestamp:64/signed,
            _Epoch:64/unsigned,
-           FilePos:32/unsigned>>} ->
+           FilePos:32/unsigned,
+           _ChType:8/unsigned>>} ->
             case Offset < ChunkId of
                 true ->
                     %% offset we are looking for is higher or equal to the start of the previous chunk
@@ -1811,7 +1839,8 @@ timestamp_idx_scan(Fd, Ts) ->
          <<ChunkId:64/unsigned,
            Timestamp:64/signed,
            Epoch:64/unsigned,
-           FilePos:32/unsigned>>} ->
+           FilePos:32/unsigned,
+           _ChType:8/unsigned>>} ->
             case Ts =< Timestamp of
                 true ->
                     ok = file:close(Fd),

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -931,7 +931,7 @@ init_offset_reader({timestamp, Ts}, #{dir := Dir} = Conf) ->
                 {value, Info} ->
                     %% segment was found, now we need to scan index to
                     %% find nearest offset
-                    ChunkId = user_chunk_id_for_timestamp(Info, Ts),
+                    ChunkId = chunk_id_for_timestamp(Info, Ts),
                     init_offset_reader(ChunkId, Conf);
                 false ->
                     %% segment was not found, attach next
@@ -1869,7 +1869,7 @@ throw_missing(Any) ->
 open(SegFile, Options) ->
     throw_missing(file:open(SegFile, Options)).
 
-user_chunk_id_for_timestamp(#seg_info{index = Idx}, Ts) ->
+chunk_id_for_timestamp(#seg_info{index = Idx}, Ts) ->
     Fd = open_index_read(Idx),
     %% scan index file for nearest timestamp
     {ChunkId, _Timestamp, _Epoch, _FilePos} = timestamp_idx_scan(Fd, Ts),
@@ -1882,7 +1882,7 @@ timestamp_idx_scan(Fd, Ts) ->
            Timestamp:64/signed,
            Epoch:64/unsigned,
            FilePos:32/unsigned,
-           ?CHNK_USER:8/unsigned>>} ->
+           _ChType:8/unsigned>>} ->
             case Ts =< Timestamp of
                 true ->
                     ok = file:close(Fd),

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1352,13 +1352,14 @@ last_user_chunk_id0([#seg_info{index = IdxFile} | Rest]) ->
         %% Do not read-ahead since we read the index file backwards chunk by chunk.
         {ok, IdxFd} = open(IdxFile, [read, raw, binary]),
         file:position(IdxFd, eof),
-        L = last_user_chunk_id_in_index(IdxFd),
+        Last = last_user_chunk_id_in_index(IdxFd),
         file:close(IdxFd),
-        case L of
+        case Last of
+            {ok, Id} ->
+                Id;
             {error, Reason} ->
                 ?DEBUG("Could not find user chunk in index file ~s (~p)", [IdxFile, Reason]),
-                last_user_chunk_id0(Rest);
-            _ -> L
+                last_user_chunk_id0(Rest)
         end
     catch
         missing_file ->
@@ -1379,7 +1380,7 @@ last_user_chunk_id_in_index(IdxFd) ->
                    _Epoch:64/unsigned,
                    _FileOffset:32/unsigned,
                    ?CHNK_USER:8/unsigned>>} ->
-                    Offset;
+                    {ok, Offset};
                 {ok,
                  <<_Offset:64/unsigned,
                    _Timestamp:64/signed,

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -40,6 +40,8 @@ all_tests() ->
      tail_info,
      init_offset_reader_empty,
      init_offset_reader,
+     init_offset_reader_last_chunk_is_not_user_chunk,
+     init_offset_reader_no_user_chunk_in_last_segment,
      init_offset_reader_timestamp,
      init_offset_reader_truncated,
      init_data_reader_empty_log,
@@ -374,6 +376,72 @@ init_offset_reader(Config, Mode) ->
         osiris_log:init_offset_reader({abs, 4}, RConf),
     {error, {offset_out_of_range, {0, 3}}} =
         osiris_log:init_offset_reader({abs, 6}, RConf),
+    ok.
+
+init_offset_reader_last_chunk_is_not_user_chunk(Config) ->
+    % | offset | chunk type |
+    % | 0      | user       |
+    % | 1      | user       |
+    % | 2      | tracking   |
+    % | 3      | tracking   |
+    EpochChunks = [{1, [<<"one">>]}, {2, [<<"two">>]}],
+    LDir = ?config(leader_dir, Config),
+    S0 = seed_log(LDir, EpochChunks, Config),
+    S1 = osiris_log:write([<<"1st tracking delta chunk">>],
+                          ?CHNK_TRK_DELTA,
+                          ?LINE,
+                          make_trailer(offset, <<"id1">>, 10),
+                          S0),
+    S2 = osiris_log:write([<<"2nd tracking delta chunk">>],
+                          ?CHNK_TRK_DELTA,
+                          ?LINE,
+                          make_trailer(offset, <<"id1">>, 11),
+                          S1),
+    osiris_log:close(S2),
+
+    Conf = ?config(osiris_conf, Config),
+    RConf = Conf#{dir => LDir, offset_ref => ?FUNCTION_NAME},
+    % Test that 'last' returns last user chunk
+    {ok, L1} = osiris_log:init_offset_reader(last, RConf),
+    ?assertEqual(1, osiris_log:next_offset(L1)),
+    osiris_log:close(L1),
+
+    % Test that 'next' returns next chunk
+    {ok, L2} = osiris_log:init_offset_reader(next, RConf),
+    ?assertEqual(4, osiris_log:next_offset(L2)),
+    osiris_log:close(L2),
+    ok.
+
+init_offset_reader_no_user_chunk_in_last_segment(Config) ->
+    % | offset | chunk type | segment |
+    % | 0      | user       | 1       |
+    % | 1      | tracking   | 1       |
+    % | 2      | tracking   | 2       |
+    Conf0 = ?config(osiris_conf, Config),
+    Conf = Conf0#{max_segment_size_bytes => 120},
+    S0 = seed_log(Conf, [{1, [<<"one">>]}], Config),
+    S1 = osiris_log:write([<<"1st tracking delta chunk">>],
+                          ?CHNK_TRK_DELTA,
+                          ?LINE,
+                          make_trailer(offset, <<"id1">>, 10),
+                          S0),
+    S2 = osiris_log:write([<<"2nd tracking delta chunk">>],
+                          ?CHNK_TRK_DELTA,
+                          ?LINE,
+                          make_trailer(offset, <<"id1">>, 11),
+                          S1),
+    osiris_log:close(S2),
+
+    RConf = Conf#{offset_ref => ?FUNCTION_NAME},
+    % test that 'last' returns last user chunk
+    {ok, L1} = osiris_log:init_offset_reader(last, RConf),
+    ?assertEqual(0, osiris_log:next_offset(L1)),
+    osiris_log:close(L1),
+
+    % test that 'next' returns next chunk
+    {ok, L2} = osiris_log:init_offset_reader(next, RConf),
+    ?assertEqual(3, osiris_log:next_offset(L2)),
+    osiris_log:close(L2),
     ok.
 
 init_offset_reader_timestamp(Config) ->


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-streams-project/issues/4 by adding the chunk type (1 byte) to the index record.
This enables us to search the index file backwards if last chunk is not a user chunk (but e.g. a tracking chunk).

Pros:
* simple
* we know the chunk type in the index record (this enables further use cases in the future: e.g. answering questions like "how many user chunk vs other chunks are in the segment?" or "query first / last chunk type" etc. without having to parse the segment file)

Cons:
* Index record increases from 28 to 29 bytes.
* ~~We might want to remove non user chunks from index anyways to enable binary searches in the index file when client attaches by offset or timestamp.~~

Pair: @mkuratczyk 