### PR TITLE
Add uncompressed length to sub batch format

### DIFF
--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -65,7 +65,8 @@
 -type retention_spec() ::
     {max_bytes, non_neg_integer()} | {max_age, milliseconds()}.
 -type writer_id() :: binary().
--type data() :: iodata() | {batch, non_neg_integer(), compression_type(), iodata()}.
+-type data() :: iodata() | {batch, non_neg_integer(), compression_type(),
+                            non_neg_integer(), iodata()}.
 -type reader_options() :: #{transport => tcp | ssl,
                             chunk_selector => all | user_data
                            }.

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -236,7 +236,9 @@
 %%   |0              |1              |2              |3              | Bytes
 %%   |0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7|0 1 2 3 4 5 6 7| Bits
 %%   +-+-----+-------+---------------+---------------+---------------+
-%%   |1| Cmp | Rsvd  | Number of records             | Length  (...) |
+%%   |1| Cmp | Rsvd  | Number of records             | Uncmp Length..|
+%%   +-+-----+-------+-------------------------------+---------------+
+%%   | Uncompressed Length                           | Length  (...) |
 %%   +-+-----+-------+-------------------------------+---------------+
 %%   | Length                                        | Body          |
 %%   +-+---------------------------------------------+               +
@@ -252,6 +254,7 @@
 %%
 %% Number of records = unsigned 16-bit integer
 %%
+%% Uncompressed Length = unsigned 32-bit integer
 %% Length = unsigned 32-bit integer
 %%
 %% Body = arbitrary data
@@ -1332,6 +1335,7 @@ parse_records(Offs,
                 0:3/unsigned, %% compression type
                 _:4/unsigned, %% reserved
                 NumRecs:16/unsigned,
+                _UncompressedLen:32/unsigned,
                 Len:32/unsigned,
                 Data:Len/binary,
                 Rem/binary>>,
@@ -1343,6 +1347,7 @@ parse_records(Offs,
                 CompType:3/unsigned, %% compression type
                 _:4/unsigned, %% reserved
                 NumRecs:16/unsigned,
+                UncompressedLen:32/unsigned,
                 Len:32/unsigned,
                 Data:Len/binary,
                 Rem/binary>>,
@@ -1350,7 +1355,7 @@ parse_records(Offs,
     %% return the first offset of the sub batch and the batch, unparsed
     %% as we don't want to decompress on the server
     parse_records(Offs + NumRecs, Rem,
-                  [{Offs, {batch, NumRecs, CompType, Data}} | Acc]).
+                  [{Offs, {batch, NumRecs, CompType, UncompressedLen, Data}} | Acc]).
 
 build_log_overview(Dir) when is_list(Dir) ->
     {Time, Result} = timer:tc(
@@ -1613,13 +1618,14 @@ segment_from_index_file(IdxFile) ->
 
 make_chunk(Blobs, TData, ChType, Timestamp, Epoch, Next) ->
     {NumEntries, NumRecords, EData} =
-        lists:foldl(fun ({batch, NumRecords, CompType, B},
+        lists:foldl(fun ({batch, NumRecords, CompType, UncompLen, B},
                          {Entries, Count, Acc}) ->
                             Data =
                                 [<<1:1, %% batch record type
                                    CompType:3/unsigned,
                                    0:4/unsigned,
                                    NumRecords:16/unsigned,
+                                   UncompLen:32/unsigned,
                                    (iolist_size(B)):32/unsigned>>,
                                  B],
                             {Entries + 1, Count + NumRecords, [Data | Acc]};

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -199,7 +199,7 @@ cluster_batch_write(Config) ->
     {ok,
      #{leader_pid := Leader, replica_pids := [ReplicaPid, ReplicaPid2]}} =
         osiris:start_cluster(Conf0),
-    Batch = {batch, 1, 0, simple(<<"mah-data">>)},
+    Batch = {batch, 1, 0, 8, simple(<<"mah-data">>)},
     ok = osiris:write(Leader, undefined, 42, Batch),
     receive
         {osiris_written, _, _WriterId, [42]} ->
@@ -1175,10 +1175,10 @@ single_node_deduplication_sub_batch(Config) ->
           dir => ?config(priv_dir, Config)},
     {ok, #{leader_pid := Leader}} = osiris:start_cluster(Conf0),
     WID = <<"wid1">>,
-    ok = osiris:write(Leader, WID, 1, {batch, 1, 0, simple(<<"data1">>)}),
+    ok = osiris:write(Leader, WID, 1, {batch, 1, 0, 5, simple(<<"data1">>)}),
     timer:sleep(50),
-    ok = osiris:write(Leader, WID, 1, {batch, 1, 0, simple(<<"data1">>)}),
-    ok = osiris:write(Leader, WID, 2, {batch, 1, 0, simple(<<"data2">>)}),
+    ok = osiris:write(Leader, WID, 1, {batch, 1, 0, 5, simple(<<"data1">>)}),
+    ok = osiris:write(Leader, WID, 2, {batch, 1, 0, 5, simple(<<"data2">>)}),
     wait_for_written([1, 2]),
     %% data1b must not have been written
     ok = validate_log(Leader, [{0, <<"data1">>}, {1, <<"data2">>}]),

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -174,7 +174,7 @@ subbatch(Config) ->
     S0 = osiris_log:init(Conf),
     IOData = [<<0:1, 2:31/unsigned, "hi">>, <<0:1, 2:31/unsigned, "h0">>],
     CompType = 0, %% no compression
-    Batch = {batch, 2, CompType, IOData},
+    Batch = {batch, 2, CompType, iolist_size(IOData), IOData},
     %% osiris_writer passes entries in reverse order
     S1 = osiris_log:write(
              lists:reverse([Batch, <<"simple">>]), S0),
@@ -199,7 +199,7 @@ subbatch_compressed(Config) ->
     S0 = osiris_log:init(Conf),
     IOData = zlib:gzip([<<0:1, 2:31/unsigned, "hi">>, <<0:1, 2:31/unsigned, "h0">>]),
     CompType = 1, %% gzip
-    Batch = {batch, 2, CompType, IOData},
+    Batch = {batch, 2, CompType, iolist_size(IOData), IOData},
     %% osiris_writer passes entries in reverse order
     S1 = osiris_log:write(
              lists:reverse([Batch, <<"simple">>]), S0),


### PR DESCRIPTION
This will allow decompressing clients to better allocate memory during
decompression etc. Will also enable calculation of the decompressed
size of the stream if that is data we want to track. No validation
of this field is performed.