### PR TITLE
Handle empty segment list for retention evaluation

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1735,6 +1735,8 @@ offset_range_from_segment_infos(SegInfos) ->
     ChunkRange = chunk_range_from_segment_infos(SegInfos),
     offset_range_from_chunk_range(ChunkRange).
 
+chunk_range_from_segment_infos([]) ->
+    empty;
 chunk_range_from_segment_infos([#seg_info{first = undefined,
                                           last = undefined}]) ->
     empty;


### PR DESCRIPTION
A retention policy can be evaluated after a stream has been deleted,
it's an asynchronous call to `osiris_retention`, and then crash
because an empty list of segments. This patchs allows the retention
call to complete, doing effectively nothing and avoiding the crash
in the logs