### PR TITLE
Refactoring and bug fixes for osiris_log

### DIFF
--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -895,7 +895,6 @@ retention_overtakes_offset_reader(Config) ->
     SegSize = 50000 * 1000,
     [LeaderNode | Replicas] =
         Nodes = [start_child_node(N, DataDir) || N <- [s1, s2, s3]],
-    % [Replica1, Replica2] = Replicas,
     Conf0 =
         #{name => Name,
           epoch => 1,


### PR DESCRIPTION
Refactoring to better handle cases where previously the `next` offset spec
would try to attach to the eof position even though this can vary depending
on whether the log is being written to during reader init. This would result
in many unexpected_chunk_id exceptions during load.

Also refactoring and simplifying other aspects of reader init to make
code clearer and in some cases faster.