### PR TITLE
Fix multiline log when starting osiris_replica_reader

### DIFF
--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -115,7 +115,7 @@ init(#{hosts := Hosts,
                 {ok, Log} =
                     osiris_writer:init_data_reader(LeaderPid, TailInfo, CntSpec),
                 CntRef = osiris_log:counters_ref(Log),
-                ?INFO("starting replica reader ~s at offset ~b Args: ~p",
+                ?INFO("starting replica reader ~s at offset ~b Args: ~0p",
                       [Name, osiris_log:next_offset(Log), Args]),
 
                 ok = gen_tcp:send(Sock, Token),


### PR DESCRIPTION
A user on Slack reported this one taking a lot of lines: https://rabbitmq.slack.com/archives/C1EDN83PA/p1634681329322400

I have not tested it.