### PR TITLE
Use rules_erlang v2 instead of bazel-erlang v1.x

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -45,8 +45,8 @@ jobs:
       run: |
         ERLANG_HOME="$(dirname $(dirname $(which erl)))"
         cat << EOF >> .bazelrc
-          build --@bazel-erlang//:erlang_version=${{ matrix.erlang_version }}
-          build --@bazel-erlang//:erlang_home=${ERLANG_HOME}
+          build --@rules_erlang//:erlang_version=${{ matrix.erlang_version }}
+          build --@rules_erlang//:erlang_home=${ERLANG_HOME}
 
           build --incompatible_strict_action_env
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+load("@rules_erlang//:erlang_app.bzl", "erlang_app", "test_erlang_app")
 load("@rules_erlang//:xref.bzl", "xref")
 load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("@rules_erlang//:ct_sharded.bzl", "ct_suite")
@@ -27,6 +27,15 @@ RUNTIME_DEPS = [
 ]
 
 erlang_app(
+    app_env = APP_ENV,
+    app_name = NAME,
+    app_version = VERSION,
+    extra_apps = EXTRA_APPS,
+    runtime_deps = RUNTIME_DEPS,
+    deps = DEPS,
+)
+
+test_erlang_app(
     app_env = APP_ENV,
     app_name = NAME,
     app_version = VERSION,

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,11 +1,7 @@
-load(
-    "@bazel-erlang//:bazel_erlang_lib.bzl",
-    "erlang_lib",
-    "test_erlang_lib",
-)
-load("@bazel-erlang//:xref.bzl", "xref")
-load("@bazel-erlang//:dialyze.bzl", "dialyze", "plt")
-load("@bazel-erlang//:ct_sharded.bzl", "ct_suite")
+load("@rules_erlang//:erlang_app.bzl", "erlang_app")
+load("@rules_erlang//:xref.bzl", "xref")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:ct_sharded.bzl", "ct_suite")
 
 NAME = "osiris"
 
@@ -23,23 +19,14 @@ EXTRA_APPS = [
 ]
 
 DEPS = [
-    "@gen_batch_server//:bazel_erlang_lib",
+    "@gen_batch_server//:erlang_app",
 ]
 
 RUNTIME_DEPS = [
-    "@seshat//:bazel_erlang_lib",
+    "@seshat//:erlang_app",
 ]
 
-erlang_lib(
-    app_env = APP_ENV,
-    app_name = NAME,
-    app_version = VERSION,
-    extra_apps = EXTRA_APPS,
-    runtime_deps = RUNTIME_DEPS,
-    deps = DEPS,
-)
-
-test_erlang_lib(
+erlang_app(
     app_env = APP_ENV,
     app_name = NAME,
     app_version = VERSION,

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 load("@rules_erlang//:xref.bzl", "xref")
-load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
+load("@rules_erlang//:plt.bzl", "plt")
+load("@rules_erlang//:dialyze.bzl", "dialyze")
 load("@rules_erlang//:ct_sharded.bzl", "ct_suite")
 
 NAME = "osiris"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,6 @@
 load("@rules_erlang//:erlang_app.bzl", "erlang_app")
 load("@rules_erlang//:xref.bzl", "xref")
-load("@rules_erlang//:plt.bzl", "plt")
-load("@rules_erlang//:dialyze.bzl", "dialyze")
+load("@rules_erlang//:dialyze.bzl", "dialyze", "plt")
 load("@rules_erlang//:ct_sharded.bzl", "ct_suite")
 
 NAME = "osiris"

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,8 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_erlang",
-    strip_prefix = "rules_erlang-2",
-    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/heads/v2.zip"],
+    sha256 = "7fd0564918537eb72294d17f5f8dc663907b16d712773b1c006e83194746a1c0",
+    strip_prefix = "rules_erlang-2.0.0",
+    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/tags/2.0.0.zip"],
 )
 
 load("@rules_erlang//:rules_erlang.bzl", "rules_erlang_dependencies")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,26 +1,25 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "bazel-erlang",
-    sha256 = "2ba878df673020ac714c050c0aaf3c66cac2f9cca0aa4259e3c74603c59e0cd0",
-    strip_prefix = "rules_erlang-1.4.0",
-    urls = ["https://github.com/rabbitmq/bazel-erlang/archive/refs/tags/1.4.0.zip"],
+    name = "rules_erlang",
+    strip_prefix = "rules_erlang-2",
+    urls = ["https://github.com/rabbitmq/rules_erlang/archive/refs/heads/v2.zip"],
 )
 
-load("@bazel-erlang//:bazel_erlang.bzl", "bazel_erlang_deps")
+load("@rules_erlang//:rules_erlang.bzl", "rules_erlang_dependencies")
 
-bazel_erlang_deps()
+rules_erlang_dependencies()
 
-load("@bazel-erlang//:github.bzl", "github_bazel_erlang_lib")
-load("@bazel-erlang//:hex_pm.bzl", "hex_pm_bazel_erlang_lib")
+load("@rules_erlang//:github.bzl", "github_erlang_app")
+load("@rules_erlang//:hex_pm.bzl", "hex_pm_erlang_app")
 
-hex_pm_bazel_erlang_lib(
+hex_pm_erlang_app(
     name = "gen_batch_server",
     sha256 = "b78679349168f27d7047f3283c9d766760b234d98c762aca9a1907f4ee3fd406",
     version = "0.8.6",
 )
 
-github_bazel_erlang_lib(
+github_erlang_app(
     name = "seshat",
     extra_apps = [
         "sasl",


### PR DESCRIPTION
rules_erlang v2 actually is bazel-erlang v2, but with a more conventional name