### PR TITLE
Avoid race condition when attaching at last + 1

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1025,7 +1025,11 @@ init_offset_reader0(OffsetSpec, #{dir := Dir} = Conf)
                 {_, empty} ->
                     0;
                 {Offset, {_, LastOffs}}
-                  when Offset > LastOffs ->
+                  when Offset == LastOffs + 1 ->
+                    %% next but we can't use `next` due to race conditions
+                    Offset;
+                {Offset, {_, LastOffs}}
+                  when Offset > LastOffs + 1 ->
                     %% out of range, clamp as `next`
                     throw({retry_with, next, Conf});
                 {Offset, {FirstOffs, _LastOffs}} ->


### PR DESCRIPTION
When an offset reader wants to attach at a given offset and this offset
is the next offset to be written in the stream there was a race condition
when we first detect the offset is out of range then retry attach with the
`next` offset spec. if a chunk was written in between these two events we
could end up skipping one or more chunks of data.