### PR TITLE
Fix various dialyzer warnings

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         erlang_version:
         - "23.3"
@@ -30,6 +31,7 @@ jobs:
   build-bazel:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         erlang_version:
         - "23.3"

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,6 +57,10 @@ plt(
 
 dialyze(
     size = "small",
+    dialyzer_opts = [
+        "-Werror_handling",
+        "-Wunmatched_returns",
+    ],
     plt = ":base_plt",
     tags = ["dialyze"],
 )

--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -255,7 +255,7 @@ start_replicas(Config, [Node | Nodes], ReplicaPids) ->
                 start_replicas(Config, Nodes, [Pid | ReplicaPids]);
             {ok, Pid, _} ->
                 start_replicas(Config, Nodes, [Pid | ReplicaPids]);
-            {already_started, Pid} ->
+            {error, {already_started, Pid}} ->
                 start_replicas(Config, Nodes, [Pid | ReplicaPids]);
             {error, Reason} ->
                 error_logger:info_msg("osiris:start_replicas failed to start replica "

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1113,7 +1113,7 @@ last_user_chunk_id0([#seg_info{index = IdxFile} = Info | Rest]) ->
     try
         %% Do not read-ahead since we read the index file backwards chunk by chunk.
         {ok, IdxFd} = open(IdxFile, [read, raw, binary]),
-        file:position(IdxFd, eof),
+        {ok, _} = file:position(IdxFd, eof),
         Last = last_user_chunk_id_in_index(IdxFd),
         _ = file:close(IdxFd),
         case Last of

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -44,6 +44,10 @@
          directory/1,
          delete_directory/1]).
 
+-ifdef(TEST).
+-export([part_test/0]).
+-endif.
+
 -define(IDX_VERSION, 1).
 -define(LOG_VERSION, 1).
 -define(IDX_HEADER, <<"OSII", ?IDX_VERSION:32/unsigned>>).

--- a/src/osiris_server_sup.erl
+++ b/src/osiris_server_sup.erl
@@ -43,7 +43,7 @@ delete_child(Node, #{name := CName} = Config) ->
     try
         case supervisor:get_childspec({?MODULE, Node}, CName) of
             {ok, _} ->
-                stop_child(Node, CName),
+                _ = stop_child(Node, CName),
                 rpc:call(Node, osiris_log, delete_directory, [Config]);
             {error, not_found} ->
                 ok

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -532,15 +532,16 @@ notify_offset_listeners(#?MODULE{cfg =
                             State) ->
     {Notify, L} =
         lists:partition(fun({_Pid, O, _}) -> O =< COffs end, L0),
-    [begin
-         Evt =
-             wrap_osiris_event(%% the per offset listener event formatter takes precedence of
-                               %% the process scoped one
-                               select_formatter(Fmt, EvtFmt),
-                               {osiris_offset, Ref, COffs}),
-         P ! Evt
-     end
-     || {P, _, Fmt} <- Notify],
+    _ = [begin
+             Evt =
+                 %% the per offset listener event formatter takes precedence of
+                 %% the process scoped one
+                 wrap_osiris_event(
+                   select_formatter(Fmt, EvtFmt),
+                   {osiris_offset, Ref, COffs}),
+             P ! Evt
+         end
+         || {P, _, Fmt} <- Notify],
     State#?MODULE{offset_listeners = L}.
 
 select_formatter(undefined, Fmt) ->

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -16,6 +16,9 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("src/osiris_peer_shim.hrl").
 
+-dialyzer({no_match, start_child_node/3}).
+-dialyzer({nowarn_function, start_peer_node_25/3}).
+
 %%%===================================================================
 %%% Common Test callbacks
 %%%===================================================================


### PR DESCRIPTION
There is still a warning for `osiris_replica.erl:542` on Erlang 25. The intention of the callback as-is is not clear to me, so I have not fixed it.

https://erlang.org/documentation/doc-13.0-rc1/lib/stdlib-4.0/doc/html/gen_server.html#Module:format_status-1