### PR TITLE
Make init_reader and init_data_reader use a consistent return value

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -809,7 +809,7 @@ truncate_to(Name, Range, [{E, ChId} | NextEOs], SegInfos) ->
                            {offset_out_of_range,
                             empty | {offset(), offset()}}} |
                           {error,
-                           {invalid_last_epoch_offset, epoch(), offset()}}.
+                           {invalid_last_offset_epoch, epoch(), offset()}}.
 init_data_reader({StartChunkId, PrevEOT}, #{dir := Dir} = Config) ->
     SegInfos = build_log_overview(Dir),
     Range = offset_range_from_segment_infos(SegInfos),
@@ -849,7 +849,7 @@ check_chunk_has_expected_epoch(ChunkId, Epoch, SegInfos) ->
         not_found ->
             %% this is unexpected and thus an error
             {error,
-             {invalid_last_epoch_offset, Epoch, unknown}};
+             {invalid_last_offset_epoch, Epoch, unknown}};
         {found, SegmentInfo = #seg_info{file = _PrevSeg}} ->
             %% prev segment exists, does it have the correct
             %% epoch?
@@ -858,7 +858,7 @@ check_chunk_has_expected_epoch(ChunkId, Epoch, SegInfos) ->
                     ok;
                 {ChunkId, OtherEpoch, _} ->
                     {error,
-                     {invalid_last_epoch_offset, Epoch, OtherEpoch}}
+                     {invalid_last_offset_epoch, Epoch, OtherEpoch}}
             end
     end.
 

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -685,7 +685,7 @@ init_data_reader_truncated(Config) ->
     osiris_log:close(L2),
 
     % %% however attaching with a different epoch should be disallowed
-    ?assertEqual({error, {invalid_last_epoch_offset, 2, 1}},
+    ?assertEqual({error, {invalid_last_offset_epoch, 2, 1}},
                  osiris_log:init_data_reader({750, {2, 700, ?LINE}}, RConf)),
     osiris_log:close(L2),
     ok.


### PR DESCRIPTION
As discovered in #68, there is a typo in one of the returned
error atoms.

We stick to "invalid_last_offset_epoch" over "invalid_last_epoch_offset"
because the check that detects an invalid value
in `osiris_log:check_chunk_has_expected_epoch/3` checks for epoch
validity, not offset validity.

This is a potentially breaking change but even in RabbitMQ-related
projects, this specific error was not handled.