### PR TITLE
Log overview optimisations

### DIFF
--- a/.github/workflows/rabbitmq-oci.yaml
+++ b/.github/workflows/rabbitmq-oci.yaml
@@ -137,7 +137,7 @@ jobs:
           RABBIT_SHA=${{ steps.load-rabbitmq-info.outputs.RABBITMQ_SHA }}
 
           OSIRIS_SHA=${{ github.event.pull_request.head.sha || github.sha }}
-          OSIRIS_ABBREV=ra-${OSIRIS_SHA:0:7}
+          OSIRIS_ABBREV=osiris-${OSIRIS_SHA:0:7}
 
           TAG_1=rabbitmq-${RABBIT_REF}-${OSIRIS_ABBREV}-${{ steps.load-info.outputs.otp }}
           TAG_2=rabbitmq-${RABBIT_REF}-${OSIRIS_ABBREV}-${{ matrix.image_tag_suffix }}

--- a/.github/workflows/rabbitmq-oci.yaml
+++ b/.github/workflows/rabbitmq-oci.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Inject the git sha as the osiris version
         working-directory: osiris
         run: |
-          sed -i"_orig" "/vsn,/ s/2\\.[0-9]\\.[0-9]/${{ github.event.pull_request.head.sha || github.sha }}/" src/osiris.app.src
+          sed -i"_orig" -E '/VERSION/ s/1\.[0-9]+\.[0-9]+/${{ github.event.pull_request.head.sha || github.sha }}/' BUILD.bazel
 
       - name: Checkout RabbitMQ
         uses: actions/checkout@v3

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1769,7 +1769,7 @@ last_epoch_offsets([FstIdxFile | _]  = IdxFiles) ->
                 {LastE, LastO, Res} =
                     lists:foldl(
                       fun(IdxFile, {E, _, EOs} = Acc) ->
-							  Fd = open_index_read(IdxFile),
+                              Fd = open_index_read(IdxFile),
                               {ok, <<Offset:64/unsigned,
                                      _Timestamp:64/signed,
                                      Epoch:64/unsigned,
@@ -1779,13 +1779,13 @@ last_epoch_offsets([FstIdxFile | _]  = IdxFiles) ->
                                   true ->
                                       %% we need to scan as the last index record
                                       %% has a greater epoch
-									  _ = file:advise(Fd, 0, 0, sequential),
-									  {ok, ?IDX_HEADER_SIZE} = file:position(Fd, ?IDX_HEADER_SIZE),
+                                      _ = file:advise(Fd, 0, 0, sequential),
+                                      {ok, ?IDX_HEADER_SIZE} = file:position(Fd, ?IDX_HEADER_SIZE),
                                       last_epoch_offset(
                                         file:read(Fd, ?INDEX_RECORD_SIZE_B), Fd,
                                         Acc);
                                   false ->
-									  ok = file:close(Fd),
+                                      ok = file:close(Fd),
                                       {Epoch, Offset, EOs}
                               end
                       end, {FstE, FstO, []}, IdxFiles),

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1329,9 +1329,11 @@ send_file(Sock,
                 true ->
                     %% TODO: use inets:setopts(Sock, {nopush, Boolean}) to avoid
                     %% sending a tiny package in the Callback
+                    ok = inet:setopts(Sock, [{nopush, true}]),
                     _ = Callback(Header, ToSend),
                     case sendfile(Transport, Fd, Sock, Pos, ToSend) of
                         ok ->
+                            ok = inet:setopts(Sock, [{nopush, false}]),
                             {ok, _} = file:position(Fd, NextFilePos),
                             {ok, State};
                         Err ->

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -225,26 +225,7 @@ init(#{name := Name,
                                   start_offset => TailInfo,
                                   reference => ExtRef,
                                   connection_token => Token},
-            RRPid =
-            case supervisor:start_child({osiris_replica_reader_sup, Node},
-                                        #{id => make_ref(),
-                                          start =>
-                                          {osiris_replica_reader, start_link,
-                                           [ReplicaReaderConf]},
-                                          %% replica readers should never be
-                                          %% restarted by their sups
-                                          %% instead they need to be re-started
-                                          %% by their replica
-                                          restart => temporary,
-                                          shutdown => 5000,
-                                          type => worker,
-                                          modules => [osiris_replica_reader]})
-            of
-                {ok, Pid} ->
-                    Pid;
-                {ok, Pid, _} ->
-                    Pid
-            end,
+            RRPid = osiris_replica_reader:start(Node, ReplicaReaderConf),
             true = link(RRPid),
             Interval = maps:get(replica_gc_interval, Config, 5000),
             erlang:send_after(Interval, self(), force_gc),

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -225,7 +225,6 @@ handle_call(_Request, _From, State) ->
 %%--------------------------------------------------------------------
 handle_cast({more_data, _LastOffset},
             #state{leader_pid = LeaderPid} = State0) ->
-    % ?DEBUG("MORE DATA ~b", [_LastOffset]),
     #state{log = Log} = State = do_sendfile(State0),
     NextOffs = osiris_log:next_offset(Log),
     ok = osiris_writer:register_data_listener(LeaderPid, NextOffs),

--- a/src/osiris_util.erl
+++ b/src/osiris_util.erl
@@ -235,6 +235,9 @@ inet_tls_enabled([{proto_dist, ["inet_tls"]} | _]) ->
 inet_tls_enabled([_Opt | Tail]) ->
     inet_tls_enabled(Tail).
 
+% -spec binary_search(Vjj
+% binary_search(Fun, List) ->
+%     Fun(hd(List)).
 
 partition_parallel(F, Es, Timeout) ->
     Parent = self(),

--- a/src/osiris_util.erl
+++ b/src/osiris_util.erl
@@ -235,10 +235,6 @@ inet_tls_enabled([{proto_dist, ["inet_tls"]} | _]) ->
 inet_tls_enabled([_Opt | Tail]) ->
     inet_tls_enabled(Tail).
 
-% -spec binary_search(Vjj
-% binary_search(Fun, List) ->
-%     Fun(hd(List)).
-
 partition_parallel(F, Es, Timeout) ->
     Parent = self(),
     Running = [{spawn_monitor(fun() -> Parent ! {self(), F(E)} end), E}

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1066,13 +1066,14 @@ many_segment_overview(Config) ->
     Conf = Conf0#{max_segment_size_bytes => 64000},
     osiris_log:close(seed_log(Conf, EpochChunks, Config)),
     %% {40051,{{0,40959},[{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]}}
-    {OverviewTaken, Res} = timer:tc(fun () ->
-                                            osiris_log:overview(maps:get(dir, Conf))
-                                    end),
+    {OverviewTaken, LogOverview} = timer:tc(fun () ->
+                                                    osiris_log:overview(maps:get(dir, Conf))
+                                            end),
     ct:pal("OverviewTaken ~p", [OverviewTaken]),
-    ct:pal("~p", [Res]),
+    ct:pal("~p", [LogOverview]),
+    %% {{0,40959},[{-1,-1},{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]}
     ?assertEqual({{0,40959},
-                  [{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]}, Res),
+                  [{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]}, LogOverview),
 
     {InitTaken, _} = timer:tc(
                        fun () ->
@@ -1122,6 +1123,18 @@ many_segment_overview(Config) ->
                          osiris_log:close(L)
                  end),
     ct:pal("OffsOffsetTakenMid ~p", [OffsOffsetTakenMid]),
+
+    %% TODO: timestamp
+
+    %% acceptor
+    {Range, EOffs} = LogOverview,
+    {InitAcceptorTaken, _} =
+        timer:tc(fun () ->
+                         osiris_log:init_acceptor(Range, EOffs, Conf#{epoch => 6})
+                 end),
+    ct:pal("InitAcceptor took ~bus", [InitAcceptorTaken]),
+
+    %% TODO: evaluate_retention
     ok.
 
 %% Utility

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1071,8 +1071,8 @@ many_segment_overview(Config) ->
                                     end),
     ct:pal("OverviewTaken ~p", [OverviewTaken ]),
     ct:pal("~p", [Res]),
-    ?assertEqual({{0,40959},[{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]},
-                 Res),
+    ?assertEqual({{0,40959},
+                  [{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]}, Res),
 
     {InitTaken, _} = timer:tc(
                        fun () ->
@@ -1081,6 +1081,33 @@ many_segment_overview(Config) ->
                        end),
     ct:pal("InitTaken ~p", [InitTaken]),
 
+    {OffsLastTaken, _} =
+        timer:tc(fun () ->
+                         {ok, L} = osiris_log:init_offset_reader(last, Conf#{epoch => 6}),
+                         osiris_log:close(L)
+                 end),
+    ct:pal("OffsLastTaken ~p", [OffsLastTaken]),
+
+    {OffsFirstTaken, _} =
+        timer:tc(fun () ->
+                         {ok, L} = osiris_log:init_offset_reader(first, Conf#{epoch => 6}),
+                         osiris_log:close(L)
+                 end),
+    ct:pal("OffsFirstTaken ~p", [OffsFirstTaken]),
+
+    {OffsNextTaken, _} =
+        timer:tc(fun () ->
+                         {ok, L} = osiris_log:init_offset_reader(next, Conf#{epoch => 6}),
+                         osiris_log:close(L)
+                 end),
+    ct:pal("OffsNextTaken ~p", [OffsNextTaken]),
+
+    % {OffsOffsetTaken, _} =
+    %     timer:tc(fun () ->
+    %                      {ok, L} = osiris_log:init_offset_reader(40000, Conf#{epoch => 6}),
+    %                      osiris_log:close(L)
+    %              end),
+    % ct:pal("OffsOffsetTaken ~p", [OffsOffsetTaken]),
     ok.
 
 %% Utility

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1125,16 +1125,27 @@ many_segment_overview(Config) ->
     ct:pal("OffsOffsetTakenMid ~p", [OffsOffsetTakenMid]),
 
     %% TODO: timestamp
+    %%
 
     %% acceptor
     {Range, EOffs} = LogOverview,
-    {InitAcceptorTaken, _} =
+    {InitAcceptorTaken, AcceptorLog} =
         timer:tc(fun () ->
                          osiris_log:init_acceptor(Range, EOffs, Conf#{epoch => 6})
                  end),
     ct:pal("InitAcceptor took ~bus", [InitAcceptorTaken]),
 
+    {InitDataReaderTaken, _} =
+        timer:tc(fun () ->
+                         {ok, L} = osiris_log:init_data_reader(
+                                     osiris_log:tail_info(AcceptorLog),
+                                     Conf#{epoch => 6}),
+                         osiris_log:close(L)
+                 end),
+    ct:pal("InitDataReaderTaken ~p", [InitDataReaderTaken]),
+
     %% TODO: evaluate_retention
+    %% TODO: init_data_reader
     ok.
 
 %% Utility

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1125,7 +1125,14 @@ many_segment_overview(Config) ->
     ct:pal("OffsOffsetTakenMid ~p", [OffsOffsetTakenMid]),
 
     %% TODO: timestamp
-    %%
+    Ts = erlang:system_time(millisecond) - 10000,
+    {TimestampTaken, _} =
+        timer:tc(fun () ->
+                         {ok, L} = osiris_log:init_offset_reader({timestamp, Ts},
+                                                                 Conf#{epoch => 6}),
+                         osiris_log:close(L)
+                 end),
+    ct:pal("TimestampTaken ~p", [TimestampTaken]),
 
     %% acceptor
     {Range, EOffs} = LogOverview,
@@ -1144,8 +1151,13 @@ many_segment_overview(Config) ->
                  end),
     ct:pal("InitDataReaderTaken ~p", [InitDataReaderTaken]),
 
-    %% TODO: evaluate_retention
-    %% TODO: init_data_reader
+    %% evaluate_retention
+    Specs = [{max_age, 60000}, {max_bytes, 5_000_000_000}],
+    {RetentionTaken, _} =
+        timer:tc(fun () ->
+                         osiris_log:evaluate_retention(maps:get(dir, Conf), Specs)
+                 end),
+    ct:pal("RetentionTaken ~p", [RetentionTaken]),
     ok.
 
 %% Utility

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1066,13 +1066,20 @@ many_segment_overview(Config) ->
     Conf = Conf0#{max_segment_size_bytes => 64000},
     osiris_log:close(seed_log(Conf, EpochChunks, Config)),
     %% {40051,{{0,40959},[{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]}}
-    {Take, Res} = timer:tc(fun () ->
-                                   osiris_log:overview(maps:get(dir, Conf))
-                           end),
-    ct:pal("TimeTaken ~p", [Take]),
+    {OverviewTaken, Res} = timer:tc(fun () ->
+                                            osiris_log:overview(maps:get(dir, Conf))
+                                    end),
+    ct:pal("OverviewTaken ~p", [OverviewTaken ]),
     ct:pal("~p", [Res]),
     ?assertEqual({{0,40959},[{1,8184},{2,16376},{3,24568},{4,32760},{5,40952}]},
                  Res),
+
+    {InitTaken, _} = timer:tc(
+                       fun () ->
+                               osiris_log:close(
+                                 osiris_log:init(Conf#{epoch => 6}))
+                       end),
+    ct:pal("InitTaken ~p", [InitTaken]),
 
     ok.
 


### PR DESCRIPTION
Various osiris_log optimisations, especially around streams with many segments.

Previously we'd always build a full log overview before doing any of, attaching, initialising or evaluating retention. With these optimisations we only scan the index and segment files we need to.


https://github.com/rabbitmq/osiris/issues/70