### PR TITLE
Retention optimisations

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1674,7 +1674,10 @@ update_retention(Retention,
 
 -spec evaluate_retention(file:filename(), [retention_spec()]) ->
     {range(), non_neg_integer()}.
-evaluate_retention(Dir, Specs) ->
+evaluate_retention(Dir, Specs) when is_list(Dir) ->
+    evaluate_retention(list_to_binary(Dir), Specs);
+evaluate_retention(Dir, Specs) when is_binary(Dir) ->
+
     {Time, Result} = timer:tc(
                        fun() ->
                                IdxFiles0 = sorted_index_files_rev(Dir),
@@ -1718,7 +1721,8 @@ eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age) ->
 
 eval_max_bytes([], _) -> [];
 eval_max_bytes([IdxFile|Rest], MaxSize) ->
-    eval_max_bytes(Rest, MaxSize - file_size(segment_from_index_file(IdxFile)), [IdxFile]).
+    eval_max_bytes(Rest, MaxSize - file_size(
+                                     segment_from_index_file(IdxFile)), [IdxFile]).
 
 eval_max_bytes([], _, Acc) ->
     Acc;
@@ -1827,7 +1831,9 @@ last_epoch_offset({ok,
 
 
 segment_from_index_file(IdxFile) when is_list(IdxFile) ->
-    unicode:characters_to_list(string:replace(IdxFile, ".index", ".segment", trailing)).
+    unicode:characters_to_list(string:replace(IdxFile, ".index", ".segment", trailing));
+segment_from_index_file(IdxFile) when is_binary(IdxFile) ->
+    unicode:characters_to_binary(string:replace(IdxFile, ".index", ".segment", trailing)).
 
 make_chunk(Blobs, TData, ChType, Timestamp, Epoch, Next) ->
     {NumEntries, NumRecords, EData} =

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -1672,7 +1672,7 @@ update_retention(Retention,
     State = State0#?MODULE{cfg = Cfg#cfg{retention = Retention}},
     trigger_retention_eval(State).
 
--spec evaluate_retention(file:filename(), [retention_spec()]) ->
+-spec evaluate_retention(file:filename_all(), [retention_spec()]) ->
     {range(), non_neg_integer()}.
 evaluate_retention(Dir, Specs) when is_list(Dir) ->
     evaluate_retention(list_to_binary(Dir), Specs);

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1037,7 +1037,12 @@ evaluate_retention_max_bytes(Config) ->
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
     ?assertEqual(1, length(SegFiles)),
-    ?assertEqual([], lists:filter(fun(S) -> lists:suffix("00000000000000000000.segment",S) end, SegFiles), "the retention process didn't delete the oldest segment"),
+    ?assertEqual([],
+                 lists:filter(fun(S) ->
+                                 lists:suffix("00000000000000000000.segment", S)
+                              end,
+                              SegFiles),
+                 "the retention process didn't delete the oldest segment"),
     ok.
 
 evaluate_retention_max_age(Config) ->
@@ -1067,7 +1072,12 @@ evaluate_retention_max_age(Config) ->
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
     ?assertEqual(1, length(SegFiles)),
-    ?assertEqual([], lists:filter(fun(S) -> lists:suffix("00000000000000000000.segment",S) end, SegFiles), "the retention process didn't delete the oldest segment"),
+    ?assertEqual([],
+                 lists:filter(fun(S) ->
+                                 lists:suffix("00000000000000000000.segment", S)
+                              end,
+                              SegFiles),
+                 "the retention process didn't delete the oldest segment"),
     ok.
 
 offset_tracking(Config) ->

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1037,6 +1037,7 @@ evaluate_retention_max_bytes(Config) ->
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
     ?assertEqual(1, length(SegFiles)),
+    ?assertEqual([], lists:filter(fun(S) -> lists:suffix("00000000000000000000.segment",S) end, SegFiles), "the retention process didn't delete the oldest segment"),
     ok.
 
 evaluate_retention_max_age(Config) ->
@@ -1057,15 +1058,16 @@ evaluate_retention_max_age(Config) ->
             filename:join(LDir, "*.segment")),
     ?assertEqual(2, length(SegFilesPre)),
     %% this should delete at least one segment as all chunks should be older
-    %% than the retention of 1000ms
-    Spec = {max_age, 1000},
-    Range = osiris_log:evaluate_retention(LDir, [Spec]),
+    %% than the retention of 1000ms; max_bytes shouldn't affect the result
+    Spec = [{max_bytes, 100000000}, {max_age, 1000}],
+    Range = osiris_log:evaluate_retention(LDir, Spec),
     %% idempotency
-    Range = osiris_log:evaluate_retention(LDir, [Spec]),
+    Range = osiris_log:evaluate_retention(LDir, Spec),
     SegFiles =
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
     ?assertEqual(1, length(SegFiles)),
+    ?assertEqual([], lists:filter(fun(S) -> lists:suffix("00000000000000000000.segment",S) end, SegFiles), "the retention process didn't delete the oldest segment"),
     ok.
 
 offset_tracking(Config) ->


### PR DESCRIPTION
* avoid going through all segments multiple times (after deleting each file) - in practice, there was usually 1 unnecessary loop (because usually we delete 1 segment)
* cheaper `segment_from_index_file` function

This implementation is roughly 50% faster in the most common case (1 segment needs to be deleted).