### PR TITLE
Add hook for file:consult/1 for TLS replication

### DIFF
--- a/test/osiris_util_SUITE.erl
+++ b/test/osiris_util_SUITE.erl
@@ -182,6 +182,7 @@ replication_over_tls_configuration_with_opt(_) ->
 
 replication_over_tls_configuration(Args) ->
     osiris_util:replication_over_tls_configuration(Args,
+                                                   fun file:consult/1,
                                                    fun tls_replication_log/3).
 
 tls_replication_log(_Level, Fmt, Args) ->


### PR DESCRIPTION
file:consult/1 is OK to parse a configuration file with some
TLS settings, but it does not support parsing "complex"
settings like a function to validate the hostname.

This commit introduces a hook so that the calling application
can provide a custom function instead of the default file:consult/1
and this way easily support parsing the app settings.

Fixes #78

Note this PR introduces a breaking change (extra parameter to pass the function in).