### PR TITLE
Fix osiris_replica:format_status/1 crash

### DIFF
--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -520,19 +520,21 @@ terminate(Reason, #?MODULE{cfg = #cfg{name = Name,
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-format_status(#?MODULE{cfg = #cfg{name = Name,
-                                  reference = ExtRef},
-                       log = Log,
-                       parse_state = ParseState,
-                       offset_listeners = OffsetListeners,
-                       committed_offset = CommittedOffset}) ->
-    #{name => Name,
-      external_reference => ExtRef,
-      has_parse_state => ParseState /= undefined,
-      log => osiris_log:format_status(Log),
-      num_offset_listeners => length(OffsetListeners),
-      committed_offset => CommittedOffset
-     }.
+format_status(#{state := #?MODULE{cfg = #cfg{name = Name,
+                                             reference = ExtRef},
+                                  log = Log,
+                                  parse_state = ParseState,
+                                  offset_listeners = OffsetListeners,
+                                  committed_offset = CommittedOffset}} = Status) ->
+    maps:update(state,
+                #{name => Name,
+                  external_reference => ExtRef,
+                  has_parse_state => ParseState /= undefined,
+                  log => osiris_log:format_status(Log),
+                  num_offset_listeners => length(OffsetListeners),
+                  committed_offset => CommittedOffset
+                 },
+                Status).
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Callback Module:format_status(Status) is new in gen_server in OTP 25.

Prior to this commit this function was used nowhere for OTP < 25.
Prior to this commit, this function crashed in OTP 25:
```
(rabbit-2@host)2> rp(sys:get_status(<0.2556.0>)).
{status,<0.2556.0>,
        {module,gen_server},
        [[{'$initial_call',{osiris_replica,init,1}},
          {'$ancestors',[osiris_server_sup,osiris_sup,<0.1693.0>]},
          {rand_seed,{#{bits => 58,jump => #Fun<rand.3.34006561>,
                        next => #Fun<rand.0.34006561>,type => exsss,
                        uniform => #Fun<rand.1.34006561>,
                        uniform_n => #Fun<rand.2.34006561>},
                      [261007605009854015|3188942010446928]}}],
         running,<0.1696.0>,[],
         [{header,"Status for generic server <0.2556.0>"},
          {data,[{"Status",running},
                 {"Parent",<0.1696.0>},
                 {"Logged events",[]}]},
          {data,[{"State",
                  "osiris_replica:format_status/1 crashed"}]}]]}
ok
```
This commit makes this function compatible with Erlang/OTP 25.