### PR TITLE
Handle corrupted index and segment files

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -563,8 +563,8 @@ maybe_fix_corrupted_files(IdxFiles) ->
     LastIdxFile = lists:last(IdxFiles),
     LastSegFile = segment_from_index_file(LastIdxFile),
     case filelib:file_size(LastSegFile) of
-        0 ->
-            % if the segment file is empty - just delete it
+        N when N =< ?HEADER_SIZE_B ->
+            % if the segment doesn't contain any chunks, just delete it
             ?WARNING("deleting an empty segment file: ~p", [LastSegFile]),
             ok = file:delete(LastIdxFile, [raw]),
             ok = file:delete(LastSegFile, [raw]),
@@ -580,7 +580,7 @@ non_empty_index_files(#{dir := Dir}) ->
 non_empty_index_files(IdxFiles) ->
     LastIdxFile = lists:last(IdxFiles),
     case filelib:file_size(LastIdxFile) of
-        0 ->
+        N when N =< ?IDX_HEADER_SIZE ->
             non_empty_index_files(IdxFiles -- [LastIdxFile]);
         _ ->
             IdxFiles

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1117,6 +1117,8 @@ init_empty_last_files(Config) ->
     {ok, SegFd} = file:open(LastSegFile, [raw, binary, write]),
     file:close(SegFd),
 
+    ?assertEqual({{0,699},[{1,650}]}, osiris_log:overview(LDir)),
+
     Conf0 = ?config(osiris_conf, Config),
     Conf = Conf0#{dir => LDir},
     osiris_log:init(Conf),

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -1067,6 +1067,10 @@ init_corrupted_log(Config) ->
     ok = file:write(IdxFd, <<0:480>>),
     ok = file:close(IdxFd),
 
+    % the overview should work even before init
+    {Range, _} = osiris_log:overview(LDir),
+    ?assertEqual({0, 1}, Range),
+
     Conf0 = ?config(osiris_conf, Config),
     Conf = Conf0#{dir => LDir},
     osiris_log:init(Conf),


### PR DESCRIPTION
If the state of the log was corrupted, streams would not be able to start. This PR implements the following changes:
* fsync index and segment when closing them
* during `init`, delete files that don't contain any useful data (empty, header-only, no valid chunks)
* during `osiris_log:overview`, which can happen before `init`, ignore files such as above (they get later deleted during `init`)

Fixes https://github.com/rabbitmq/osiris/issues/79