### PR TITLE
Fix slow tracking

### DIFF
--- a/src/osiris_tracking.erl
+++ b/src/osiris_tracking.erl
@@ -71,10 +71,6 @@ add(TrkId, TrkType, TrkData, ChunkId,
     update_tracking(TrkId, TrkType, TrkData,
                     ChunkId, State#?MODULE{pending = Pend}).
 
-%% Convert for example 'offset' to 'offsets'.
-plural(Word) when is_atom(Word) ->
-    list_to_atom(atom_to_list(Word) ++ "s").
-
 -spec flush(state()) -> {iodata(), state()}.
 flush(#?MODULE{pending = Pending} = State) ->
     TData = maps:fold(fun(TrkType, TrackingMap, Acc) ->
@@ -193,6 +189,10 @@ max_sequences(#?MODULE{cfg = #cfg{max_sequences = MaxSequences}}) ->
     MaxSequences.
 
 %% INTERNAL
+plural(sequence) -> sequences;
+plural(offset) -> offsets;
+plural(timestamp) -> timestamps.
+
 update_tracking(TrkId, sequence, Tracking, ChId,
                 #?MODULE{sequences = Seqs0} = State) when is_integer(ChId) ->
     State#?MODULE{sequences = Seqs0#{TrkId => {ChId, Tracking}}};


### PR DESCRIPTION
Running
```
java -jar target/stream-perf-test.jar --producer-names="my-producer-%s-%d"
```
for 20 seconds against RabbitMQ server with 2 CPUs.

Prior to this commit 12.3% of CPU time was spent in function `plural/1` 🙈.

Before
```
Summary: published 987863 msg/s, confirmed 987374 msg/s, consumed 987173 msg/s, latency 95th 15 ms, chunk size 4238
```

After
```
Summary: published 1357363 msg/s, confirmed 1356868 msg/s, consumed 1356868 msg/s, latency 95th 11 ms, chunk size 4186
```

Thanks @kjnilsson for spotting this!