### PR TITLE
Use normal exit reason on replica reader shutdown

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -82,7 +82,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "cac7afd62f347f575141db3394ff04c9742a6f63b943ad9fc088280d2b751d6a",
+    sha256 = "2cda9a35cf20f4d1307ad807c76aca0cb961bfe497bb349f739f93be88bcb425",
     strip_prefix = "tls-gen-main",
     urls = ["https://github.com/rabbitmq/tls-gen/archive/refs/heads/main.zip"],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -84,5 +84,5 @@ filegroup(
 """,
     sha256 = "cac7afd62f347f575141db3394ff04c9742a6f63b943ad9fc088280d2b751d6a",
     strip_prefix = "tls-gen-main",
-    urls = ["https://github.com/michaelklishin/tls-gen/archive/refs/heads/main.zip"],
+    urls = ["https://github.com/rabbitmq/tls-gen/archive/refs/heads/main.zip"],
 )

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -483,7 +483,7 @@ handle_info({'EXIT', RRPid, shutdown = Info},
                                 replica_reader_pid = RRPid}} = State) ->
     %% any replica reader exit is troublesome and requires the replica to also
     %% terminate
-    ?ERROR_(Name, "replica reader ~w exited with ~w", [RRPid, Info]),
+    ?INFO_(Name, "replica reader ~w exited with ~w", [RRPid, Info]),
     %% the replica reader shut down normally, so we use the normal return code
     %% to avoid logging the whole stack trace
     {stop, normal, State};

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -478,6 +478,15 @@ handle_info({'DOWN', _Ref, process, Pid, Info},
     ?DEBUG_(Name, "DOWN received for Pid ~w, Info: ~w",
            [Pid, Info]),
     {noreply, State};
+handle_info({'EXIT', RRPid, shutdown = Info},
+            #?MODULE{cfg = #cfg{name = Name,
+                                replica_reader_pid = RRPid}} = State) ->
+    %% any replica reader exit is troublesome and requires the replica to also
+    %% terminate
+    ?ERROR_(Name, "replica reader ~w exited with ~w", [RRPid, Info]),
+    %% the replica reader shut down normally, so we use the normal return code
+    %% to avoid logging the whole stack trace
+    {stop, normal, State};
 handle_info({'EXIT', RRPid, Info},
             #?MODULE{cfg = #cfg{name = Name,
                                 replica_reader_pid = RRPid}} = State) ->


### PR DESCRIPTION
Using a customer exit reason triggers the logging of the stack
trace, which is not necessary when reader just stops, e.g.
when the replica reader node shuts down.

References #89, rabbitmq/rabbitmq-server#5393