### PR TITLE
Ensure a writer|replica start initialises first offset

### DIFF
--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -161,12 +161,13 @@ handle_continue(#{name := Name,
     process_flag(trap_exit, true),
     process_flag(message_queue_data, off_heap),
     ORef = atomics:new(2, [{signed, true}]),
+    atomics:put(ORef, 2, -1),
     CntName = {?MODULE, ExtRef},
     Log = osiris_log:init(Config#{dir => Dir,
                                   first_offset_fun =>
-                                  fun (Fst) ->
-                                          atomics:put(ORef, 2, Fst)
-                                  end,
+                                      fun (Fst) ->
+                                              atomics:put(ORef, 2, Fst)
+                                      end,
                                   counter_spec =>
                                       {CntName, ?ADD_COUNTER_FIELDS}}),
     Trk = osiris_log:recover_tracking(Log),


### PR DESCRIPTION
Else this counter may be incorrect or remain set to -1 until
next time retention runs. As we want to expose this valute to users
we need to ensure it is always correctly initialised. Fixes #98 


This Pr also includes an `osiris:get_stat/1` API to get the committed and first offsets from any member of a stream. Fixes #97 