### PR TITLE
Try other addresses for TLS replication on failure

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -82,7 +82,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "2cda9a35cf20f4d1307ad807c76aca0cb961bfe497bb349f739f93be88bcb425",
+    sha256 = "22d1f92c04cc41e19b2c332c958f2d5c364a1c7ae78549041187e9e0a0080bf3",
     strip_prefix = "tls-gen-main",
     urls = ["https://github.com/rabbitmq/tls-gen/archive/refs/heads/main.zip"],
 )

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -77,7 +77,7 @@ maybe_connect(ssl, [H | T], Port, Options) ->
         {error, E} ->
             ?DEBUG("osiris replica TLS connection refused, host:~p - port: ~p", [H, Port]),
             ?DEBUG("error while trying to establish TLS connection ~p", [E]),
-            {error, connection_refused}
+            maybe_connect(ssl, T, Port, Options)
     end.
 
 maybe_add_sni_option(H) when is_binary(H) ->


### PR DESCRIPTION
Not only on handshake failure.

ML thread: https://groups.google.com/g/rabbitmq-users/c/7zGWzNExxp8/m/9-w6esEZBAAJ