### PR TITLE
osiris_replica: optimisations

### DIFF
--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -28,9 +28,6 @@
          configure_logger/1,
          get_stats/1]).
 
-%% holds static or rarely changing fields
--record(cfg, {}).
--record(?MODULE, {cfg :: #cfg{}}).
 
 -type config() ::
     #{name := string(),
@@ -38,8 +35,6 @@
       event_formatter => {module(), atom(), list()},
       retention => [osiris:retention_spec()],
       atom() => term()}.
-
--opaque state() :: #?MODULE{}.
 
 -type mfarg() :: {module(), atom(), list()}.
 -type offset() :: non_neg_integer().
@@ -77,8 +72,7 @@
                             chunk_selector => all | user_data
                            }.
 
--export_type([state/0,
-              config/0,
+-export_type([config/0,
               offset/0,
               epoch/0,
               tail_info/0,
@@ -277,9 +271,9 @@ configure_logger(Module) ->
                             first_chunk_id => integer()}.
 get_stats(Pid)
   when node(Pid) =:= node() ->
-    {ok, #{offset_ref := ORef}} = gen:call(Pid, '$gen_call', get_reader_context),
-    #{committed_chunk_id => osiris_log_shared:committed_chunk_id(ORef),
-      first_chunk_id => osiris_log_shared:first_chunk_id(ORef),
-      last_chunk_id => osiris_log_shared:last_chunk_id(ORef)};
+    {ok, #{shared := Shared}} = gen:call(Pid, '$gen_call', get_reader_context),
+    #{committed_chunk_id => osiris_log_shared:committed_chunk_id(Shared),
+      first_chunk_id => osiris_log_shared:first_chunk_id(Shared),
+      last_chunk_id => osiris_log_shared:last_chunk_id(Shared)};
 get_stats(Pid) when is_pid(Pid) ->
     erpc:call(node(Pid), ?MODULE, ?FUNCTION_NAME, [Pid]).

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -372,7 +372,6 @@
 -record(read,
         {type :: data | offset,
          offset_ref :: undefined | atomics:atomics_ref(),
-         last_offset = 0 :: offset(),
          next_offset = 0 :: offset(),
          transport :: transport(),
          chunk_selector :: all | user_data}).
@@ -2317,8 +2316,7 @@ can_read_next_offset(#read{type = data}) ->
     true.
 
 incr_next_offset(Num, #read{next_offset = NextOffset} = Read) ->
-    Read#read{last_offset = NextOffset,
-              next_offset = NextOffset + Num}.
+    Read#read{next_offset = NextOffset + Num}.
 
 make_file_name(N, Suff) ->
     lists:flatten(

--- a/src/osiris_log_shared.erl
+++ b/src/osiris_log_shared.erl
@@ -1,0 +1,72 @@
+-module(osiris_log_shared).
+
+-define(COMMITTED_IDX, 1).
+-define(FIRST_IDX, 2).
+-define(LAST_IDX, 3).
+
+-export([
+         new/0,
+         committed_chunk_id/1,
+         first_chunk_id/1,
+         last_chunk_id/1,
+         set_committed_chunk_id/2,
+         set_first_chunk_id/2,
+         set_last_chunk_id/2
+        ]).
+
+-type chunk_id() :: -1 | non_neg_integer().
+
+-spec new() -> atomics:atomics_ref().
+new() ->
+    %% Oh why, oh why did we think the first chunk id in
+    %% a stream should have offset 0?
+    Ref = atomics:new(3, [{signed, true}]),
+    atomics:put(Ref, ?COMMITTED_IDX, -1),
+    atomics:put(Ref, ?FIRST_IDX, -1),
+    atomics:put(Ref, ?LAST_IDX, -1),
+    Ref.
+
+-spec committed_chunk_id(atomics:atomics_ref()) -> chunk_id().
+committed_chunk_id(Ref) ->
+    atomics:get(Ref, ?COMMITTED_IDX).
+
+-spec first_chunk_id(atomics:atomics_ref()) -> chunk_id().
+first_chunk_id(Ref) ->
+    atomics:get(Ref, ?FIRST_IDX).
+
+-spec last_chunk_id(atomics:atomics_ref()) -> chunk_id().
+last_chunk_id(Ref) ->
+    atomics:get(Ref, ?LAST_IDX).
+
+-spec set_committed_chunk_id(atomics:atomics_ref(), chunk_id()) -> ok.
+set_committed_chunk_id(Ref, Value) when is_integer(Value) ->
+    atomics:put(Ref, ?COMMITTED_IDX, Value).
+
+-spec set_first_chunk_id(atomics:atomics_ref(), chunk_id()) -> ok.
+set_first_chunk_id(Ref, Value) when is_integer(Value) ->
+    atomics:put(Ref, ?FIRST_IDX, Value).
+
+-spec set_last_chunk_id(atomics:atomics_ref(), chunk_id()) -> ok.
+set_last_chunk_id(Ref, Value) when is_integer(Value) ->
+    atomics:put(Ref, ?LAST_IDX, Value).
+
+
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+basics_test() ->
+    R = new(),
+    ?assertEqual(-1, committed_chunk_id(R)),
+    ?assertEqual(-1, first_chunk_id(R)),
+    ?assertEqual(-1, last_chunk_id(R)),
+    ok = set_committed_chunk_id(R, 2),
+    ok = set_first_chunk_id(R, 1),
+    ok = set_last_chunk_id(R, 3),
+    ?assertEqual(2, committed_chunk_id(R)),
+    ?assertEqual(1, first_chunk_id(R)),
+    ?assertEqual(3, last_chunk_id(R)),
+
+    ok.
+
+-endif.

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -112,7 +112,7 @@ init_per_testcase(TestCase, Config) ->
         name => atom_to_list(TestCase),
         epoch => 1,
         readers_counter_fun => fun(_) -> ok end,
-        offset_ref => ORef,
+        shared => ORef,
         options => #{}}},
      {dir, Dir}
      | Config].
@@ -197,7 +197,7 @@ subbatch(Config) ->
     ?assertEqual(3, osiris_log:next_offset(S1)),
     OffRef = osiris_log_shared:new(),
     {ok, R0} =
-        osiris_log:init_offset_reader(0, Conf#{offset_ref => OffRef}),
+        osiris_log:init_offset_reader(0, Conf#{shared => OffRef}),
     {end_of_stream, R1} = osiris_log:read_chunk_parsed(R0),
     osiris_log_shared:set_committed_chunk_id(OffRef, 0), %% first chunk index
 
@@ -221,7 +221,7 @@ subbatch_compressed(Config) ->
     ?assertEqual(3, osiris_log:next_offset(S1)),
     OffRef = osiris_log_shared:new(),
     {ok, R0} =
-        osiris_log:init_offset_reader(0, Conf#{offset_ref => OffRef}),
+        osiris_log:init_offset_reader(0, Conf#{shared => OffRef}),
     {end_of_stream, R1} = osiris_log:read_chunk_parsed(R0),
     osiris_log_shared:set_committed_chunk_id(OffRef, 0), %% first chunk index
 
@@ -237,10 +237,9 @@ subbatch_compressed(Config) ->
 read_chunk_parsed(Config) ->
     Conf = ?config(osiris_conf, Config),
     S0 = osiris_log:init(Conf),
-    {ok, R0} = osiris_log:init_data_reader({0, empty}, Conf),
-    ct:pal("before"),
+    RConf = Conf#{shared => osiris_log:get_shared(S0)},
+    {ok, R0} = osiris_log:init_data_reader({0, empty}, RConf),
     {end_of_stream, R1} = osiris_log:read_chunk_parsed(R0),
-    ct:pal("empty"),
     _S1 = osiris_log:write([<<"hi">>], S0),
     ?assertMatch({[{0, <<"hi">>}], _}, osiris_log:read_chunk_parsed(R1)),
     ok.
@@ -248,7 +247,8 @@ read_chunk_parsed(Config) ->
 read_chunk_parsed_2(Config) ->
     Conf = ?config(osiris_conf, Config),
     S0 = osiris_log:init(Conf),
-    {ok, R0} = osiris_log:init_data_reader({0, empty}, Conf),
+    RConf = Conf#{shared => osiris_log:get_shared(S0)},
+    {ok, R0} = osiris_log:init_data_reader({0, empty}, RConf),
     {end_of_stream, R1} = osiris_log:read_chunk_parsed(R0, with_header),
     _S1 = osiris_log:write([<<"hi">>], S0),
     {ok,
@@ -264,14 +264,15 @@ read_chunk_parsed_multiple_chunks(Config) ->
     %% osiris_writer passes entries in reversed order
     S1 = osiris_log:write(
              lists:reverse(Entries), S0),
-    _S2 = osiris_log:write([<<"hi-again">>], S1),
-    {ok, R0} = osiris_log:init_data_reader({0, empty}, Conf),
+    S2 = osiris_log:write([<<"hi-again">>], S1),
+    RConf = Conf#{shared => osiris_log:get_shared(S2)},
+    {ok, R0} = osiris_log:init_data_reader({0, empty}, RConf),
     {[{0, <<"hi">>}, {1, <<"hi-there">>}], R1} =
         osiris_log:read_chunk_parsed(R0),
     ?assertMatch({[{2, <<"hi-again">>}], _},
                  osiris_log:read_chunk_parsed(R1)),
     %% open another reader at a later index
-    {ok, R2} = osiris_log:init_data_reader({2, {1, 0, 0}}, Conf),
+    {ok, R2} = osiris_log:init_data_reader({2, {1, 0, 0}}, RConf),
     ?assertMatch({[{2, <<"hi-again">>}], _},
                  osiris_log:read_chunk_parsed(R2)),
     ok.
@@ -283,15 +284,16 @@ read_chunk_parsed_2_multiple_chunks(Config) ->
     %% osiris_writer passes entries in reversed order
     S1 = osiris_log:write(
              lists:reverse(Entries), S0),
-    _S2 = osiris_log:write([<<"hi-again">>], S1),
-    {ok, R0} = osiris_log:init_data_reader({0, empty}, Conf),
+    S2 = osiris_log:write([<<"hi-again">>], S1),
+    RConf = Conf#{shared => osiris_log:get_shared(S2)},
+    {ok, R0} = osiris_log:init_data_reader({0, empty}, RConf),
     {ok, #{num_records := 2},
      [{0, <<"hi">>}, {1, <<"hi-there">>}], R1} =
         osiris_log:read_chunk_parsed(R0, with_header),
     ?assertMatch({ok, #{num_records := 1}, [{2, <<"hi-again">>}], _},
                  osiris_log:read_chunk_parsed(R1, with_header)),
     %% open another reader at a later index
-    {ok, R2} = osiris_log:init_data_reader({2, {1, 0, 0}}, Conf),
+    {ok, R2} = osiris_log:init_data_reader({2, {1, 0, 0}}, RConf),
     ?assertMatch({ok, #{num_records := 1}, [{2, <<"hi-again">>}], _},
                  osiris_log:read_chunk_parsed(R2, with_header)),
     ok.
@@ -301,7 +303,7 @@ read_header(Config) ->
     W0 = osiris_log:init(Conf),
     OffRef = osiris_log_shared:new(),
     {ok, R0} =
-        osiris_log:init_offset_reader(first, Conf#{offset_ref => OffRef}),
+        osiris_log:init_offset_reader(first, Conf#{shared => OffRef}),
     {end_of_stream, R1} = osiris_log:read_header(R0),
     W1 = osiris_log:write([<<"hi">>, <<"ho">>], W0),
     _W = osiris_log:write([<<"hum">>], W1),
@@ -348,7 +350,7 @@ write_multi_log(Config) ->
     osiris_log_shared:set_committed_chunk_id(OffRef, NextOffset),
     %% ensure all records can be read
     {ok, R0} =
-        osiris_log:init_offset_reader(first, Conf#{offset_ref => OffRef}),
+        osiris_log:init_offset_reader(first, Conf#{shared => OffRef}),
 
     R1 = lists:foldl(fun(_, Acc0) ->
                         {Records = [_ | _], Acc} =
@@ -428,7 +430,7 @@ init_offset_reader(Config, Mode) ->
         [{1, [<<"one">>]}, {2, [<<"two">>]}, {3, [<<"three">>, <<"four">>]}],
     LDir = ?config(leader_dir, Config),
     Conf = ?config(osiris_conf, Config),
-    set_offset_ref(Conf, 3),
+    set_shared(Conf, 3),
     LLog0 = seed_log(LDir, EpochChunks, Config),
     osiris_log:close(LLog0),
     RConf = Conf#{dir => LDir, mode => Mode},
@@ -490,7 +492,7 @@ init_offset_reader_last_chunk_is_not_user_chunk(Config) ->
 
     Conf = ?config(osiris_conf, Config),
     RConf = Conf#{dir => LDir},
-    set_offset_ref(RConf, 4),
+    set_shared(RConf, 4),
     % Test that 'last' returns last user chunk
     {ok, L1} = osiris_log:init_offset_reader(last, RConf),
     ?assertEqual(1, osiris_log:next_offset(L1)),
@@ -510,7 +512,7 @@ init_offset_reader_no_user_chunk_in_last_segment(Config) ->
     Conf0 = ?config(osiris_conf, Config),
     Conf = Conf0#{max_segment_size_bytes => 120},
     S0 = seed_log(Conf, [{1, [<<"one">>]}], Config),
-    set_offset_ref(Conf, 2),
+    set_shared(Conf, 2),
     S1 = osiris_log:write([<<"1st tracking delta chunk">>],
                           ?CHNK_TRK_DELTA,
                           ?LINE,
@@ -570,7 +572,7 @@ init_offset_reader_timestamp_empty(Config) ->
     % application:set_env(osiris, max_segment_size_chunks, 1),
     Conf = Conf0#{max_segment_size_chunks => 1},
     LLog0 = seed_log(LDir, EpochChunks, Config),
-    set_offset_ref(Conf, 3),
+    set_shared(Conf, 3),
     osiris_log:close(LLog0),
     RConf = Conf#{dir => LDir},
 
@@ -590,7 +592,7 @@ init_offset_reader_timestamp(Config) ->
     Conf0 = ?config(osiris_conf, Config),
     Conf = Conf0#{max_segment_size_chunks => 1},
     LLog0 = seed_log(LDir, EpochChunks, Config),
-    set_offset_ref(Conf, 3),
+    set_shared(Conf, 3),
     osiris_log:close(LLog0),
     RConf = Conf#{dir => LDir},
 
@@ -632,7 +634,7 @@ init_offset_reader_timestamp_multi_segment(Config) ->
     Conf = Conf0#{max_segment_size_chunks => 1},
     LLog0 = seed_log(LDir, EpochChunks, Config),
 
-    set_offset_ref(Conf, 3),
+    set_shared(Conf, 3),
     osiris_log:close(LLog0),
     application:unset_env(osiris, max_segment_size_chunks),
     RConf = Conf#{dir => LDir},
@@ -668,7 +670,7 @@ init_offset_reader_truncated(Config) ->
     Conf = ?config(osiris_conf, Config),
     LDir = ?config(leader_dir, Config),
     LLog0 = seed_log(LDir, EpochChunks, Config),
-    set_offset_ref(Conf, 1000),
+    set_shared(Conf, 1000),
     RConf = Conf#{dir => LDir},
     osiris_log:close(LLog0),
 
@@ -713,7 +715,8 @@ init_data_reader_next(Config) ->
     _LLog0 = seed_log(LDir, [{1, ["one"]}], Config),
     %% seed is up to date
     FLog0 = seed_log(FDir, [{1, ["one"]}], Config),
-    RRConf = Conf#{dir => LDir},
+    RRConf = Conf#{dir => LDir,
+                   shared => osiris_log:get_shared(FLog0)},
     %% the next offset, i.e. offset 0
     {ok, _RLog0} =
         osiris_log:init_data_reader(
@@ -726,7 +729,8 @@ init_data_reader_empty_log(Config) ->
     LLog0 = seed_log(LDir, [], Config),
     %% an empty log
     FLog0 = seed_log(?config(follower1_dir, Config), [], Config),
-    RRConf = Conf#{dir => ?config(leader_dir, Config)},
+    RRConf = Conf#{dir => ?config(leader_dir, Config),
+                   shared => osiris_log:get_shared(FLog0)},
     %% the next offset, i.e. offset 0
     {ok, RLog0} =
         osiris_log:init_data_reader(
@@ -756,7 +760,8 @@ init_data_reader_truncated(Config) ->
     Conf = ?config(osiris_conf, Config),
     LDir = ?config(leader_dir, Config),
     LLog0 = seed_log(LDir, EpochChunks, Config),
-    RConf = Conf#{dir => LDir},
+    RConf = Conf#{dir => LDir,
+                  shared => osiris_log:get_shared(LLog0)},
     osiris_log:close(LLog0),
 
     %% "Truncate" log by deleting first segment
@@ -899,9 +904,11 @@ accept_chunk(Config) ->
 
     F0 = osiris_log:init(FConf),
 
+    RConf = LConf#{shared => osiris_log:get_shared(L2)},
+
     {ok, R0} =
         osiris_log:init_data_reader(
-            osiris_log:tail_info(F0), LConf),
+            osiris_log:tail_info(F0), RConf),
     {Chunk1, R1} = read_chunk(R0),
     % ct:pal("Chunk1 ~w", [Chunk1]),
     F1 = osiris_log:accept_chunk(Chunk1, F0),
@@ -940,9 +947,11 @@ accept_chunk_truncates_tail(Config) ->
     {Range, EOffs} = osiris_log:overview(LDir),
     ALog0 =
         osiris_log:init_acceptor(Range, EOffs, Conf#{dir => FDir, epoch => 2}),
+
+    RConf = Conf#{dir => LDir,
+                  shared => osiris_log:get_shared(FLog0)},
     {ok, RLog0} =
-        osiris_log:init_data_reader(
-            osiris_log:tail_info(ALog0), Conf#{dir => LDir}),
+        osiris_log:init_data_reader(osiris_log:tail_info(ALog0), RConf),
     {ok, {_, _, _, Hd, Ch, Tr}, _RLog} = osiris_log:read_chunk(RLog0),
     ALog = osiris_log:accept_chunk([Hd, Ch, Tr], ALog0),
     osiris_log:close(ALog),
@@ -1092,7 +1101,7 @@ init_corrupted_log(Config) ->
     Conf0 = ?config(osiris_conf, Config),
     Conf = Conf0#{dir => LDir},
     _ = osiris_log:init(Conf),
-    set_offset_ref(Conf, 2),
+    set_shared(Conf, 2),
 
     % after osiris_log:init, the sizes of the index and segment files
     % should be as they were before they got corrrupted
@@ -1145,7 +1154,7 @@ init_only_one_corrupted_segment(Config) ->
     Conf0 = ?config(osiris_conf, Config),
     Conf = Conf0#{dir => LDir},
     _ = osiris_log:init(Conf),
-    set_offset_ref(Conf, 1000),
+    set_shared(Conf, 1000),
 
     % there should be one segment, with nothing but headers
     % and its name should be the same as it was before
@@ -1194,7 +1203,7 @@ init_empty_last_files(Config) ->
     Conf0 = ?config(osiris_conf, Config),
     Conf = Conf0#{dir => LDir},
     _ = osiris_log:init(Conf),
-    set_offset_ref(Conf, 2),
+    set_shared(Conf, 2),
 
     % the last segment and index files should no longer exist
     RecoveredIdxFiles =
@@ -1490,5 +1499,5 @@ make_trailer(Type, K, V) ->
       K/binary,
       V:64/unsigned>>.
 
-set_offset_ref(#{offset_ref := Ref}, Value) ->
+set_shared(#{shared := Ref}, Value) ->
     osiris_log_shared:set_committed_chunk_id(Ref, Value).


### PR DESCRIPTION
1. To avoid blocking the supervisor (which is shared with the writer and all other replicas) this commit moves the initialisation work into handle_continue. osiris_replica:start/2 now does a call into the started process to still block until init work is complete.
2. To avoid replica readers having to check the disk every time they reach `end_of_stream` writers and replicas now share the last chunk id via the shared atomic value avoiding the need to check the disk unless needed to open the next segment file.

These two changes improve the scalability of using multiple streams.