### PR TITLE
Cache reader context

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -40,7 +40,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "22d1f92c04cc41e19b2c332c958f2d5c364a1c7ae78549041187e9e0a0080bf3",
+    # sha256 = "22d1f92c04cc41e19b2c332c958f2d5c364a1c7ae78549041187e9e0a0080bf3",
     strip_prefix = "tls-gen-main",
     urls = ["https://github.com/rabbitmq/tls-gen/archive/refs/heads/main.zip"],
 )

--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -196,7 +196,7 @@ init_reader(Pid, OffsetSpec, CounterSpec) ->
 init_reader(Pid, OffsetSpec, {_, _} = CounterSpec, Options)
     when is_pid(Pid) andalso node(Pid) =:= node() ->
     ?DEBUG("osiris: initialising reader. Spec: ~w", [OffsetSpec]),
-    {ok, Ctx0} = gen:call(Pid, '$gen_call', get_reader_context),
+    Ctx0 = osiris_util:get_reader_context(Pid),
     Ctx = Ctx0#{counter_spec => CounterSpec,
                 options => Options},
     osiris_log:init_offset_reader(OffsetSpec, Ctx).
@@ -274,7 +274,7 @@ configure_logger(Module) ->
                             first_chunk_id => integer()}.
 get_stats(Pid)
   when node(Pid) =:= node() ->
-    {ok, #{shared := Shared}} = gen:call(Pid, '$gen_call', get_reader_context),
+    #{shared := Shared} = osiris_util:get_reader_context(Pid),
     #{committed_chunk_id => osiris_log_shared:committed_chunk_id(Shared),
       first_chunk_id => osiris_log_shared:first_chunk_id(Shared),
       last_chunk_id => osiris_log_shared:last_chunk_id(Shared)};

--- a/src/osiris_ets.erl
+++ b/src/osiris_ets.erl
@@ -1,0 +1,77 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2022 VMware, Inc. or its affiliates.  All rights reserved.
+%%
+
+-module(osiris_ets).
+
+-behaviour(gen_server).
+
+%% API functions
+-export([start_link/0]).
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+init(_) ->
+    _ = ets:new(osiris_reader_context_cache, [set, named_table, public]),
+    {ok, #state{}}.
+
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% @spec terminate(Reason, State) -> void()
+terminate(_Reason, _State) ->
+    ok.
+
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -575,6 +575,7 @@ terminate(_Reason, undefined) ->
 terminate(Reason, #?MODULE{cfg = #cfg{name = Name,
                                       socket = Sock}, log = Log}) ->
     ?DEBUG_(Name, "terminating with ~w ", [Reason]),
+    _ = ets:delete(osiris_reader_context_cache, self()),
     ok = osiris_log:close(Log),
     ok = gen_tcp:close(Sock),
     ok.

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -197,7 +197,7 @@ handle_continue(#{name := Name0,
                     %% re-discover the committed offset
                     osiris_writer:ack(LeaderPid, {LastChId, LastTs})
             end,
-            ?INFO_(Name, "osiris replicas starting in epoch ~b, next offset ~b, tail info ~w",
+            ?INFO_(Name, "osiris replica starting in epoch ~b, next offset ~b, tail info ~w",
                    [Epoch, NextOffset, TailInfo]),
 
             %% HostName: append the HostName to the Ip(s) list: in some cases
@@ -246,8 +246,8 @@ handle_continue(#{name := Name0,
             RRPid = osiris_replica_reader:start(Node, ReplicaReaderConf),
             true = link(RRPid),
             GcInterval0 = application:get_env(osiris,
-                                             replica_forced_gc_default_interval,
-                                             4999),
+                                              replica_forced_gc_default_interval,
+                                              4999),
 
             GcInterval1 = case is_integer(GcInterval0) of
                               true ->
@@ -258,6 +258,11 @@ handle_continue(#{name := Name0,
                           end,
             counters:put(CntRef, ?C_COMMITTED_OFFSET, -1),
             counters:put(CntRef, ?C_EPOCH, Epoch),
+            Shared = osiris_log:get_shared(Log),
+            osiris_util:cache_reader_context(self(), Dir, Name, Shared, ExtRef,
+                                             fun(Inc) ->
+                                                     counters:add(CntRef, ?C_READERS, Inc)
+                                             end),
             EvtFmt = maps:get(event_formatter, Config, undefined),
             {noreply,
              #?MODULE{cfg =

--- a/src/osiris_sup.erl
+++ b/src/osiris_sup.erl
@@ -22,6 +22,10 @@ init([]) ->
           intensity => 5,
           period => 5},
     %% todo put under own sup
+    Ets =
+        #{id => osiris_ets,
+          type => worker,
+          start => {osiris_ets, start_link, []}},
     Retention =
         #{id => osiris_retention,
           type => worker,
@@ -34,4 +38,4 @@ init([]) ->
         #{id => osiris_replica_reader_sup,
           type => supervisor,
           start => {osiris_replica_reader_sup, start_link, []}},
-    {ok, {SupFlags, [Retention, ServerSup, ReplicaReader]}}.
+    {ok, {SupFlags, [Ets, Retention, ServerSup, ReplicaReader]}}.

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -97,7 +97,7 @@ start_link(Config) ->
 overview(Pid) when node(Pid) == node() ->
     case erlang:is_process_alive(Pid) of
         true ->
-            #{dir := Dir} = gen_batch_server:call(Pid, get_reader_context),
+            #{dir := Dir} = osiris_util:get_reader_context(Pid),
             {ok, osiris_log:overview(Dir)};
         false ->
             {error, no_process}
@@ -105,9 +105,14 @@ overview(Pid) when node(Pid) == node() ->
 
 init_data_reader(Pid, TailInfo, Config)
   when node(Pid) == node() ->
-    Ctx0 = gen_batch_server:call(Pid, get_reader_context),
-    Ctx = maps:merge(Ctx0, Config),
-    osiris_log:init_data_reader(TailInfo, Ctx).
+    case erlang:is_process_alive(Pid) of
+        true ->
+            Ctx0 = osiris_util:get_reader_context(Pid),
+            Ctx = maps:merge(Ctx0, Config),
+            osiris_log:init_data_reader(TailInfo, Ctx);
+        false ->
+            {error, no_process}
+    end.
 
 register_data_listener(Pid, Offset) ->
     ok =
@@ -188,6 +193,11 @@ handle_continue(#{name := Name0,
     ?INFO("osiris_writer:init/1: name: ~s last offset: ~b "
           "committed chunk id: ~b epoch: ~b",
           [Name, LastOffs, CommittedOffset, Epoch]),
+    Shared = osiris_log:get_shared(Log),
+    osiris_util:cache_reader_context(self(), Dir, Name, Shared, ExtRef,
+                                     fun(Inc) ->
+                                             counters:add(CntRef, ?C_READERS, Inc)
+                                     end),
     {ok,
      #?MODULE{cfg =
                   #cfg{name = Name,

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -288,6 +288,7 @@ terminate(Reason,
                    cfg = #cfg{name = Name}}) ->
     ?INFO("osiris_writer:terminate/2: name ~s reason: ~w",
           [Name, Reason]),
+    _ = ets:delete(osiris_reader_context_cache, self()),
     ok = osiris_log:close(Log),
     [osiris_replica_reader:stop(Pid) || {Pid, _} <- Listeners],
     ok.


### PR DESCRIPTION
Cache reader context data in ETS table to avoid process call.

Which could time out during high load.

Bug fixes:

Fixes diverged replica truncation bug.

Fixes bug in acceptor initialisation that would ignore the requested initial_offset passed in the config.

Better handling of suddenly closed TCP connection in replica readers.
