### PR TITLE
Handle errors on replica and replica reader

### DIFF
--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -578,7 +578,11 @@ terminate(Reason, #?MODULE{cfg = #cfg{name = Name,
     ?DEBUG_(Name, "terminating with ~w ", [Reason]),
     _ = ets:delete(osiris_reader_context_cache, self()),
     ok = osiris_log:close(Log),
-    ok = gen_tcp:close(Sock),
+    case Sock of
+        undefined -> ok;
+        _ ->
+            ok = gen_tcp:close(Sock)
+    end,
     ok.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
The initialisation function of the replica reader expected `osiris_writer:init_data_reader/3` to generate an exception, but it returns a tagged error instead. This PR tries to handle better the error so the long `badmatch` stacktrace is replaced by a log warning and controlled stop. 

Also `osiris_replica` needs to handle the case on terminate when the socked hasn't yet been initialised, otherwise `inet_tcp:close/1` returns a `function_clause`. 