### PR TITLE
Fix case_clause in osiris_replica_reader

### DIFF
--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -105,25 +105,19 @@ stop(Pid) ->
     gen_server:cast(Pid, stop).
 
 start(Node, ReplicaReaderConf) when is_map(ReplicaReaderConf) ->
-    case supervisor:start_child({osiris_replica_reader_sup, Node},
-                                #{id => make_ref(),
-                                  start =>
-                                  {osiris_replica_reader, start_link,
-                                   [ReplicaReaderConf]},
-                                  %% replica readers should never be
-                                  %% restarted by their sups
-                                  %% instead they need to be re-started
-                                  %% by their replica
-                                  restart => temporary,
-                                  shutdown => 5000,
-                                  type => worker,
-                                  modules => [osiris_replica_reader]})
-    of
-        {ok, Pid} ->
-            Pid;
-        {ok, Pid, _} ->
-            Pid
-    end.
+    supervisor:start_child({osiris_replica_reader_sup, Node},
+                           #{id => make_ref(),
+                             start =>
+                                 {osiris_replica_reader, start_link,
+                                  [ReplicaReaderConf]},
+                             %% replica readers should never be
+                             %% restarted by their sups
+                             %% instead they need to be re-started
+                             %% by their replica
+                             restart => temporary,
+                             shutdown => 5000,
+                             type => worker,
+                             modules => [osiris_replica_reader]}).
 
 %%%===================================================================
 %%% gen_server callbacks


### PR DESCRIPTION
If starting the reader returns an error, osiris_replica should handle it and stop nicely.

```
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0> ** When Server state == "osiris_replica:format_status/1 crashed"
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0> ** Reason for termination ==
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0> ** {{case_clause,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>         {error,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>             {writer_unavailable,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                 {child,undefined,#Ref<0.345803779.3209691138.252379>,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                     {osiris_replica_reader,start_link,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                         [#{connection_token =>
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                                <<79,244,157,81,13,204,83,140,110,215,130,98,6,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                                  11,105,219,146,240,155,218,41,227,243,229,121,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                                  194,114,145,155,164,2,218>>,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            hosts =>
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                                [{192,168,0,118},"dparracorb0633Q","localhost"],
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            leader_pid => <44206.1950.0>,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            name => <<"__invalid_policy_1688551225701999000">>,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            port => 6396,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            reference =>
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                                {resource,<<"/">>,queue,<<"invalid_policy">>},
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            replica_pid => <0.1717.0>,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            start_offset => {0,empty},
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                            transport => tcp}]},
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                     temporary,false,5000,worker,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>                     [osiris_replica_reader]}}}},
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>     [{osiris_replica_reader,start,2,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>          [{file,"src/osiris_replica_reader.erl"},{line,108}]},
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>      {osiris_replica,handle_continue,2,
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>          [{file,"src/osiris_replica.erl"},{line,246}]},
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>      {gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1123}]},
2023-07-05 12:00:26.911201+02:00 [error] <0.1717.0>      {gen_server,loop,7,[{file,"gen_server.erl"},{line,865}]},

```