### PR TITLE
osiris_replica: Handle undefined state in format_status/1

### DIFF
--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -595,6 +595,10 @@ terminate(Reason, #?MODULE{cfg = #cfg{name = Name,
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
+format_status(undefined) ->
+    %% Handle formatting the status when the server shut down before start-up,
+    %% for example when the rpc call in `handle_continue/2' fails.
+    undefined;
 format_status(#{state := #?MODULE{cfg = #cfg{name = Name,
                                              reference = ExtRef},
                                   log = Log,


### PR DESCRIPTION
This is a mostly cosmetic change that improves the error report when `osiris_replica` terminates early. The server state may be `undefined` when terminating if the rpc call to `osiris_writer` fails in the `handle_continue/2` block. See: https://github.com/rabbitmq/osiris/blob/fbe6fa80bcba19db727e4a5b426df456993063c5/src/osiris_replica.erl#L158-L162