### PR TITLE
Use the additional rabbitmq erlang-packages bzlmod registry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,8 @@
 build --enable_bzlmod
 
+build --registry=https://bcr.bazel.build/
+build --registry=https://raw.githubusercontent.com/rabbitmq/bazel-central-registry/erlang-packages/
+
 build --incompatible_strict_action_env
 build --local_test_jobs=1
 


### PR DESCRIPTION
so that our modules publishes can be handled independently of the bazel team