### PR TITLE
Delete folders of deleted replicas

### DIFF
--- a/src/osiris_server_sup.erl
+++ b/src/osiris_server_sup.erl
@@ -60,13 +60,13 @@ delete_child(Node, #{name := Name} = Config) ->
                         _ = stop_child(Node, OthName),
                         rpc:call(Node, osiris_log, delete_directory, [Config]);
                     {error, not_found} ->
-                        ok
+                        rpc:call(Node, osiris_log, delete_directory, [Config])
                 end
         end
     catch
         _:{noproc, _} ->
             %% Whole supervisor or app is already down - i.e. stop_app
-            ok
+            rpc:call(Node, osiris_log, delete_directory, [Config])
     end.
 
 flip_name(N) when is_binary(N) ->


### PR DESCRIPTION
Without this change, if a replica was delete when the node was down (and therefore it wasn't immediately deleted), orphaned folders would pile up. With this change, when the node is started again, it will clean up the unneeded folder.

Part of https://github.com/rabbitmq/rabbitmq-server/issues/9282