### PR TITLE
Optimise index scanning

### DIFF
--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -158,8 +158,8 @@ init(#{hosts := Hosts,
                     {stop, Reason}
             end;
         {error, Reason} ->
-            ?WARN_(Name, "could not connect osiris to replica at ~0p Reason:",
-                   [Hosts, Reason]),
+            ?WARN_(Name, "could not connect replica reader to replica at ~0p port ~b, Reason: ~0p",
+                   [Hosts, Port, Reason]),
             {stop, Reason}
     end.
 

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -108,12 +108,12 @@ init(#{hosts := Hosts,
        connection_token := Token}) ->
     process_flag(trap_exit, true),
 
-    ?DEBUG("~ts: trying to connect to replica at ~p", [Name, Hosts]),
+    ?DEBUG("~ts: trying to connect to replica at ~0p", [Name, Hosts]),
 
     case maybe_connect(Name, Transport, Hosts, Port, connect_options())
     of
         {ok, Sock, Host} ->
-            ?DEBUG_(Name, "successfully connected to host ~p port ~b",
+            ?DEBUG_(Name, "successfully connected to host ~0p port ~b",
                     [Host, Port]),
             CntId = {?MODULE, ExtRef, Host, Port},
             CntSpec = {CntId, ?COUNTER_FIELDS},
@@ -143,22 +143,22 @@ init(#{hosts := Hosts,
                     {ok, State};
                 {error, no_process} ->
                     ?WARN_(Name,
-                           "osiris writer for ~p is down, replica reader will not start",
+                           "osiris writer for ~0p is down, replica reader will not start",
                           [ExtRef]),
                     {stop, writer_unavailable};
                 {error, {offset_out_of_range, Range} = Reason} ->
                     ?WARN_(Name,
-                           "data reader found an offset out of range: ~p, replica reader will not start",
+                           "data reader found an offset out of range: ~0p, replica reader will not start",
                           [Range]),
                     {stop, Reason};
                 {error, {invalid_last_offset_epoch, Epoch, Offset} = Reason} ->
                     ?WARN_(Name,
-                           "data reader found an invalid last offset epoch: epoch ~p offset ~p, replica reader will not start",
+                           "data reader found an invalid last offset epoch: epoch ~0p offset ~0p, replica reader will not start",
                            [Epoch, Offset]),
                     {stop, Reason}
             end;
         {error, Reason} ->
-            ?WARN_(Name, "could not connect osiris to replica at ~p Reason:",
+            ?WARN_(Name, "could not connect osiris to replica at ~0p Reason:",
                    [Hosts, Reason]),
             {stop, Reason}
     end.
@@ -251,12 +251,12 @@ handle_info({ssl_closed, Socket},
     {stop, normal, State};
 handle_info({tcp_error, Socket, Error},
             #state{name = Name, socket = Socket} = State) ->
-    ?DEBUG_(Name, "Socket error ~p. "
+    ?DEBUG_(Name, "Socket error ~0p. "
            "Exiting...", [Error]),
     {stop, {tcp_error, Error}, State};
 handle_info({ssl_error, Socket, Error},
             #state{name = Name, socket = Socket} = State) ->
-    ?DEBUG_(Name, "TLS socket error ~p. "
+    ?DEBUG_(Name, "TLS socket error ~0p. "
            "Exiting...", [Error]),
     {stop, {ssl_error, Error}, State};
 handle_info({'EXIT', Ref, Info}, #state{name = Name} = State) ->
@@ -366,17 +366,17 @@ setopts(ssl, Sock, Opts) ->
 maybe_connect(_Name, _, [], _Port, _Options) ->
     {error, connection_refused};
 maybe_connect(Name, tcp, [H | T], Port, Options) ->
-    ?DEBUG_(Name, "trying to connect to ~p on port ~b", [H, Port]),
+    ?DEBUG_(Name, "trying to connect to ~0p on port ~b", [H, Port]),
     case gen_tcp:connect(H, Port, Options) of
         {ok, Sock} ->
             {ok, Sock, H};
         {error, Reason} ->
-            ?DEBUG_(Name, "connection refused, reason: ~w host:~p - port: ~p",
+            ?DEBUG_(Name, "connection refused, reason: ~w host:~0p - port: ~0p",
                     [Reason, H, Port]),
             maybe_connect(Name, tcp, T, Port, Options)
     end;
 maybe_connect(Name, ssl, [H | T], Port, Options) ->
-    ?DEBUG_(Name, "trying to establish TLS connection to ~p using port ~b", [H, Port]),
+    ?DEBUG_(Name, "trying to establish TLS connection to ~0p using port ~b", [H, Port]),
     Opts = Options ++
         application:get_env(osiris, replication_client_ssl_options, []) ++
         maybe_add_sni_option(H),
@@ -384,12 +384,12 @@ maybe_connect(Name, ssl, [H | T], Port, Options) ->
         {ok, Sock} ->
             {ok, Sock, H};
         {error, {tls_alert, {handshake_failure, _}}} ->
-            ?DEBUG_(Name, "TLS connection refused (handshake failure), host:~p - port: ~p",
+            ?DEBUG_(Name, "TLS connection refused (handshake failure), host:~0p - port: ~0p",
                     [H, Port]),
             maybe_connect(Name, ssl, T, Port, Options);
         {error, E} ->
-            ?DEBUG_(Name, "TLS connection refused, host:~p - port: ~p", [H, Port]),
-            ?DEBUG_(Name, "error while trying to establish TLS connection ~p", [E]),
+            ?DEBUG_(Name, "TLS connection refused, host:~0p - port: ~0p", [H, Port]),
+            ?DEBUG_(Name, "error while trying to establish TLS connection ~0p", [E]),
             maybe_connect(Name, ssl, T, Port, Options)
     end.
 

--- a/src/osiris_util.erl
+++ b/src/osiris_util.erl
@@ -139,7 +139,7 @@ replication_over_tls_configuration(InitArgs, FileConsultFun, LogFun) ->
                 {error, Error} ->
                     LogFun(warn,
                            "Error while reading TLS "
-                           ++ "distributon option file ~ts: ~p",
+                           ++ "distributon option file ~ts: ~0p",
                            [OptFile, Error]),
                     LogFun(warn,
                            "Stream replication over TLS will NOT be enabled",
@@ -148,7 +148,7 @@ replication_over_tls_configuration(InitArgs, FileConsultFun, LogFun) ->
                 R ->
                     LogFun(warn,
                            "Unexpected result while reading TLS distributon "
-                           "option file ~ts: ~p",
+                           "option file ~ts: ~0p",
                            [OptFile, R]),
                     LogFun(warn,
                            "Stream replication over TLS will NOT be enabled",
@@ -274,7 +274,7 @@ get_reader_context(Pid)
   when is_pid(Pid) andalso node(Pid) == node() ->
     case ets:lookup(osiris_reader_context_cache, Pid) of
         [] ->
-            {ok, Ctx0} = gen:call(Pid, '$gen_call', get_reader_context),
+            {ok, Ctx0} = gen:call(Pid, '$gen_call', get_reader_context, infinity),
             Ctx0;
         [{_Pid, Dir, Name, Shared, Ref, ReadersCountersFun}] ->
             #{dir => Dir,


### PR DESCRIPTION
Optimise index scanning using a skip search approach.
This improves worst case index scanning scenarios
by making the scanning to find offset as well as epoch / chunk_id
paris (as part of osiris_log:overview/1) up to 10x faster.

Move reader context caching earlier in writer initialisation

To increase the chance of a replica calling osiris_writer:overview/1
will get the cached reader context instead of having to call into
the writer process.

Unfortunately we can only cache the context after log init but
it can be done before any other work such as tracking recovery.

Make the replica call into the leader process (`osiris_writer:overview/1`) use infinity timeout to avoid cases where writer init takes so long a replica times out and has to be restarted.

osiris_log refactoring and log improvements.