### PR TITLE
Add chunk iterator API to osiris_log

### DIFF
--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -74,6 +74,8 @@
                 batch() |
                 {filter_value(), iodata() | batch()}.
 
+%% returned when reading
+-type entry() :: binary() | batch().
 -type reader_options() :: #{transport => tcp | ssl,
                             chunk_selector => all | user_data,
                             filter_spec => osiris_bloom:filter_spec()
@@ -89,7 +91,8 @@
               retention_spec/0,
               timestamp/0,
               writer_id/0,
-              data/0]).
+              data/0,
+             entry/0]).
 
 -spec start_cluster(config()) ->
     {ok, config()} |

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -32,6 +32,7 @@
          chunk_iterator/1,
          chunk_iterator/2,
          iterator_next/1,
+         batch_records/2,
          read_chunk/1,
          read_chunk_parsed/1,
          read_chunk_parsed/2,
@@ -1748,6 +1749,13 @@ next_chunk_pos(Fd, Pos) ->
            _Reserved:24>>} = file:pread(Fd, Pos, ?HEADER_SIZE_B),
     Pos + ?HEADER_SIZE_B + FSize + Size + TSize.
 
+
+%% utility function to parse an uncompressed subbatch into records
+batch_records(ChId, {batch, _NumRecords, 0, _UncompLen, Data}) ->
+    Records = lists:reverse(parse_subbatch(ChId, Data, [])),
+    {ok, Records};
+batch_records(_ChId, {batch, _NumRecords, CompType, _UncompLen, _Data}) ->
+    {error, {compression_type_not_supported, CompType}}.
 
 parse_subbatch(_Offs, <<>>, Acc) ->
     Acc;

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -36,6 +36,8 @@ all_tests() ->
      write_batch_with_filters_variable_size,
      subbatch,
      subbatch_compressed,
+     iterator_read_chunk,
+     iterator_read_chunk_mixed_sizes_with_credit,
      read_chunk_parsed,
      read_chunk_parsed_2,
      read_chunk_parsed_multiple_chunks,
@@ -86,6 +88,18 @@ all_tests() ->
      overview
     ].
 
+-define(assertMatch_(Guard, Expr),
+        begin
+            case (Expr) of
+                Guard -> ok;
+                X__V -> erlang:error({assertMatch,
+                                      [{module, ?MODULE},
+                                       {line, ?LINE},
+                                       {expression, (??Expr)},
+                                       {pattern, (??Guard)},
+                                       {value, X__V}]})
+            end
+        end).
 
 
 groups() ->
@@ -301,6 +315,52 @@ subbatch_compressed(Config) ->
 
     osiris_log:close(S1),
     osiris_log:close(R1),
+    ok.
+
+iterator_read_chunk(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    S0 = osiris_log:init(Conf),
+    Shared = osiris_log:get_shared(S0),
+    RConf = Conf#{shared => Shared},
+    {ok, R0} = osiris_log:init_offset_reader(0, RConf),
+    {end_of_stream, R1} = osiris_log:chunk_iterator(R0),
+    IOData = <<0:1, 2:31/unsigned, "hi", 0:1, 2:31/unsigned, "h0">>,
+    CompType = 0, %% no compression
+    Batch = {batch, 2, CompType, byte_size(IOData), IOData},
+    EntriesRev = [Batch,
+                  <<"ho">>,
+                  {<<"filter">>, <<"hi">>}],
+    {ChId, _S1} = write_committed(EntriesRev, S0),
+    {ok, _H, I0, _R2} = osiris_log:chunk_iterator(R1),
+    HoOffs = ChId + 1,
+    BatchOffs = ChId + 2,
+    {{ChId, <<"hi">>}, I1} = osiris_log:iterator_next(I0),
+    {{HoOffs, <<"ho">>}, I2} = osiris_log:iterator_next(I1),
+    {{BatchOffs, Batch}, I} = osiris_log:iterator_next(I2),
+    ?assertMatch(end_of_chunk, osiris_log:iterator_next(I)),
+    ok.
+
+iterator_read_chunk_mixed_sizes_with_credit(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    S0 = osiris_log:init(Conf),
+    Shared = osiris_log:get_shared(S0),
+    RConf = Conf#{shared => Shared},
+    {ok, R0} = osiris_log:init_offset_reader(0, RConf),
+    {end_of_stream, R1} = osiris_log:chunk_iterator(R0),
+    Big = crypto:strong_rand_bytes(100_000),
+    EntriesRev = [Big,
+                  <<"ho">>,
+                  {<<"filter">>, <<"hi">>}],
+    {ChId, _S1} = write_committed(EntriesRev, S0),
+    %% this is a less than ideal case where we have one large and two very
+    %% small entries inthe same batch. The read ahead only
+    {ok, _H, I0, _R2} = osiris_log:chunk_iterator(R1, 2),
+    HoOffs = ChId + 1,
+    BigOffs = ChId + 2,
+    {{ChId, <<"hi">>}, I1} = osiris_log:iterator_next(I0),
+    {{HoOffs, <<"ho">>}, I2} = osiris_log:iterator_next(I1),
+    {{BigOffs, Big}, I} = osiris_log:iterator_next(I2),
+    ?assertMatch(end_of_chunk, osiris_log:iterator_next(I)),
     ok.
 
 read_chunk_parsed(Config) ->
@@ -1702,3 +1762,13 @@ make_trailer(Type, K, V) ->
 
 set_shared(#{shared := Ref}, Value) ->
     osiris_log_shared:set_committed_chunk_id(Ref, Value).
+
+%% writes and commits the chunk
+write_committed(Entries, S0) ->
+    ChId = osiris_log:next_offset(S0),
+    S = osiris_log:write(Entries, S0),
+    Shared = osiris_log:get_shared(S0),
+    osiris_log_shared:set_committed_chunk_id(Shared, ChId),
+    osiris_log_shared:set_last_chunk_id(Shared, ChId),
+    {ChId, S}.
+

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -338,6 +338,9 @@ iterator_read_chunk(Config) ->
     {{HoOffs, <<"ho">>}, I2} = osiris_log:iterator_next(I1),
     {{BatchOffs, Batch}, I} = osiris_log:iterator_next(I2),
     ?assertMatch(end_of_chunk, osiris_log:iterator_next(I)),
+    %% test batch parsing
+    ?assertMatch({ok,[{2,<<"hi">>},{3,<<"h0">>}]},
+                 osiris_log:batch_records(BatchOffs, Batch)),
     ok.
 
 iterator_read_chunk_mixed_sizes_with_credit(Config) ->


### PR DESCRIPTION
To allow readers to read chunks incrementally rather than in one go.

osiris_log:read_chunk_parsed/2 has been updated to use the chunk iterator API as well but with a full chunk read ahead configuration.

osiris_log:chunk_iterator/2 tries to estimate a read ahead amount based on the "credit hint" that can be passed to indicate how many entries are likely to be read in one go.