### PR TITLE
Correctly handle case where replica exits in handle_continue.

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -35,7 +35,6 @@ jobs:
       fail-fast: false
       matrix:
         otp_major:
-        - "24"
         - "25"
         - "26"
     steps:

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -268,7 +268,8 @@ handle_continue(#{name := Name0,
                               log = Log,
                               parse_state = undefined}};
                 {error, Reason} ->
-                    {stop, Reason, undefined}
+                    ?WARN_(Name, " failed to start replica reader. Reason ~0p", [Reason]),
+                    {stop, {shutdown, Reason}, undefined}
             end
     end.
 

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -585,10 +585,6 @@ terminate(Reason, #?MODULE{cfg = #cfg{name = Name,
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-format_status(undefined) ->
-    %% Handle formatting the status when the server shut down before start-up,
-    %% for example when the rpc call in `handle_continue/2' fails.
-    undefined;
 format_status(#{state := #?MODULE{cfg = #cfg{name = Name,
                                              reference = ExtRef},
                                   log = Log,
@@ -603,8 +599,11 @@ format_status(#{state := #?MODULE{cfg = #cfg{name = Name,
                   num_offset_listeners => length(OffsetListeners),
                   committed_offset => CommittedOffset
                  },
-                Status).
-
+                Status);
+format_status(Status) ->
+    %% Handle formatting the status when the server shut down before start-up,
+    %% for example when the rpc call in `handle_continue/2' fails.
+    Status.
 %%%===================================================================
 %%% Internal functions
 %%%===================================================================

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -144,8 +144,14 @@ init(#{hosts := Hosts,
                     {ok, State};
                 {error, no_process} ->
                     ?WARN_(Name,
-                           "osiris writer for ~0p is down,
-                           replica reader will not start",
+                           "osiris writer for ~0p is down, "
+                           "replica reader will not start",
+                          [ExtRef]),
+                    {stop, normal};
+                {error, enoent} ->
+                    ?WARN_(Name,
+                           "data reader for ~0p encountered an 'enonet' error whilst
+                           initialising, replica reader will not start",
                           [ExtRef]),
                     {stop, normal};
                 {error, {offset_out_of_range, Range}} ->


### PR DESCRIPTION
Avoids "format_status crashed errors in log files"