### PR TITLE
Set fullsweep_after=0 on the writer process

### DIFF
--- a/erlang.mk
+++ b/erlang.mk
@@ -1465,7 +1465,7 @@ pkg_eunit_formatters_description = Because eunit's output sucks. Let's make it b
 pkg_eunit_formatters_homepage = https://github.com/seancribbs/eunit_formatters
 pkg_eunit_formatters_fetch = git
 pkg_eunit_formatters_repo = https://github.com/seancribbs/eunit_formatters
-pkg_eunit_formatters_commit = master
+pkg_eunit_formatters_commit = main
 
 PACKAGES += euthanasia
 pkg_euthanasia_name = euthanasia

--- a/src/osiris_writer.erl
+++ b/src/osiris_writer.erl
@@ -206,6 +206,7 @@ handle_continue(#{name := Name,
   when ?IS_STRING(Name) ->
     process_flag(trap_exit, true),
     process_flag(message_queue_data, off_heap),
+    process_flag(fullsweep_after, 0),
     Log = osiris_log:init(Config),
     %% reader context can only be cached _after_ log init as we need to ensure
     %% there is at least 1 segment/index pair and also that the log has been


### PR DESCRIPTION
This seems to increase throughput by ~10% on OTP26 and even more on OTP27. In particular, it seems to solve the performance regression with small messages on OTP 27:

stream-perf-test -s 100 results (single node, everything local): OTP26 as-is: 880k
OTP26, fullsweep_after 0: 940k
OTP27 as-is: 750k
OTP27 fullsweep_after 0: 1M