### PR TITLE
Make it possible to configure IP address family for Osiris replica listeners

### DIFF
--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -746,7 +746,11 @@ listener_opts(tcp) ->
     ReuseAddr = application:get_env(osiris, replica_reuseaddr, true),
     Linger = application:get_env(osiris, replica_linger, true),
     LingerTimeout = application:get_env(osiris, replica_linger_timeout, 0),
+
+    IPAddrFamily = osiris_util:get_inet_address_family(),
+
     [binary,
+     IPAddrFamily,
      {reuseaddr, ReuseAddr},
      {linger, {Linger, LingerTimeout}},
      {backlog, 0},

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -371,7 +371,9 @@ close(ssl, Socket) ->
 connect_options() ->
     SndBuf = application:get_env(osiris, replica_sndbuf, ?DEF_SND_BUF),
     KeepAlive = application:get_env(osiris, replica_keepalive, false),
+    IPAddrFamily = osiris_util:get_inet_address_family(),
     [binary,
+     IPAddrFamily,
      {packet, 0},
      {nodelay, true},
      {sndbuf, SndBuf},

--- a/src/osiris_util.erl
+++ b/src/osiris_util.erl
@@ -18,6 +18,7 @@
          get_replication_configuration_from_tls_dist/0,
          get_replication_configuration_from_tls_dist/1,
          get_replication_configuration_from_tls_dist/2,
+         get_inet_address_family/0,
          partition_parallel/3,
          normalise_name/1,
          get_reader_context/1,
@@ -238,6 +239,14 @@ eval_term(V) ->
     {ok, AbsForm} = erl_parse:parse_exprs(Tokens),
     {value, Term, _Bs} = erl_eval:exprs(AbsForm, erl_eval:new_bindings()),
     Term.
+
+-spec get_inet_address_family() -> inet | inet6.
+get_inet_address_family() ->
+    case application:get_env(osiris, replica_ip_address_family, inet) of
+        inet  -> inet;
+        inet6 -> inet6;
+        _     -> inet
+    end.
 
 inet_tls_enabled([]) ->
     false;

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -27,7 +27,10 @@
 %%%===================================================================
 
 all() ->
-    [{group, tests}].
+    [
+        {group, tests},
+        {group, ipv6}
+    ].
 
 all_tests() ->
     [single_node_write,
@@ -84,10 +87,20 @@ all_tests() ->
      combine_ips_hosts_test,
      empty_last_segment].
 
+%% Isolated to avoid test interference
+ipv6_tests() ->
+    [
+        cluster_write_replication_plain_ipv6,
+        cluster_write_replication_tls_ipv6
+    ].
+
 -define(BIN_SIZE, 800).
 
 groups() ->
-    [{tests, [], all_tests()}].
+    [
+        {tests, [], all_tests()},
+        {ipv6,  [], ipv6_tests()}
+    ].
 
 init_per_suite(Config) ->
     osiris:configure_logger(logger),
@@ -96,10 +109,18 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
+init_per_group(ipv6, Config) ->
+    application:set_env(kernel, prevent_overlapping_partitions, false),
+    application:set_env(osiris, replica_ip_address_family, inet6),
+    Config;
 init_per_group(_Group, Config) ->
     application:set_env(kernel, prevent_overlapping_partitions, false),
+    application:set_env(osiris, replica_ip_address_family, inet),
     Config.
 
+end_per_group(ipv6, _Config) ->
+    application:set_env(osiris, replica_ip_address_family, inet),
+    ok;
 end_per_group(_Group, _Config) ->
     ok.
 
@@ -142,6 +163,14 @@ extra_init(cluster_write_replication_tls) ->
         {secure_renegotiate, true},
         {verify,verify_peer}
     ]),
+    ok;
+extra_init(cluster_write_replication_tls_ipv6) ->
+    extra_init(cluster_write_replication_tls),
+    application:set_env(osiris, replica_ip_address_family, inet6),
+    ok;
+extra_init(cluster_write_replication_plain_ipv6) ->
+    application:set_env(osiris, replication_transport, tcp),
+    application:set_env(osiris, replica_ip_address_family, inet6),
     ok;
 extra_init(_) ->
     application:set_env(osiris, replication_transport, tcp),
@@ -287,7 +316,13 @@ start_many_clusters(Config) ->
 cluster_write_replication_plain(Config) ->
     cluster_write(Config, undefined).
 
+cluster_write_replication_plain_ipv6(Config) ->
+    cluster_write(Config, undefined).
+
 cluster_write_replication_tls(Config) ->
+    cluster_write(Config, undefined).
+
+cluster_write_replication_tls_ipv6(Config) ->
     cluster_write(Config, undefined).
 
 cluster_write_replication_plain_with_filter(Config) ->


### PR DESCRIPTION
Some environments are IPv6-only or at least strive to be, plus RabbitMQ allows for IPv6-only configuration
in a lot places.

Note that instead of introducing a new transport type (e.g. tcp6 or tcp_ipv6, tls_ipv6), which requires
many scattered changes, this introduces a separate option that is passed to `gen_tcp:listen/2`,
`inet:setopts/2` and such.

CT tests use a new group to avoid interference.

The `rabbitmq.conf` part belongs to the RabbitMQ server repository.

Closes #116.