### PR TITLE
Replica: Handle nodedowns when starting replica reader.

### DIFF
--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -531,7 +531,12 @@ handle_info({'EXIT', RRPid, Info},
                                 replica_reader_pid = RRPid}} = State) ->
     %% any replica reader exit is troublesome and requires the replica to also
     %% terminate
-    ?ERROR_(Name, "replica reader ~w exited with ~w", [RRPid, Info]),
+    case lists:member(Info, [normal, shutdown]) of
+        true ->
+            ?DEBUG_(Name, "replica reader ~w exited with ~w", [RRPid, Info]);
+        false ->
+            ?ERROR_(Name, "replica reader ~w exited with ~w", [RRPid, Info])
+    end,
     {stop, {shutdown, Info}, State};
 handle_info({'EXIT', Ref, normal},
             #?MODULE{cfg = #cfg{name = Name}} = State) ->

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -85,7 +85,8 @@ all_tests() ->
      single_node_reader_counters,
      cluster_reader_counters,
      combine_ips_hosts_test,
-     empty_last_segment].
+     empty_last_segment,
+     replica_reader_nodedown_noproc].
 
 %% Isolated to avoid test interference
 ipv6_tests() ->
@@ -1893,6 +1894,16 @@ empty_last_segment(Config) ->
         osiris:start_cluster(Conf1),
     timer:sleep(100),
     ?assert(erlang:is_process_alive(Leader2)),
+    ok.
+
+replica_reader_nodedown_noproc(_Config) ->
+    %% unit test to ensure we handle down nodes gracefully.
+    {error, {nodedown, 'banana@fruit'}} =
+        osiris_replica_reader:start('banana@fruit', #{}),
+
+    _ = application:stop(osiris),
+    {error, noproc} =
+        osiris_replica_reader:start(node(), #{}),
     ok.
 
 %% Utility


### PR DESCRIPTION
It is possible that the writer's node could go down in between querying the writer for it's log overview and then starting the replica reader. This commit handles that potentially common scenarion more gracefully.