### PR TITLE
Bump `gen_batch_server` to `0.9.1`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PROJECT = osiris
 # This project uses an app.src file
 
 LOCAL_DEPS = sasl crypto
-dep_gen_batch_server = hex 0.9.0
+dep_gen_batch_server = hex 0.9.1
 dep_seshat = hex 1.0.1
 DEPS = gen_batch_server seshat
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {project_plugins, [rebar3_format]}.
 
 {deps, [
-        {gen_batch_server, "0.9.0"},
+        {gen_batch_server, "0.9.1"},
         {seshat, "1.0.1"}
 
 ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,5 @@
 {"1.2.0",
-[{<<"gen_batch_server">>,{pkg,<<"gen_batch_server">>,<<"0.9.0">>},0},
+[{<<"gen_batch_server">>,{pkg,<<"gen_batch_server">>,<<"0.9.1">>},0},
  {<<"seshat">>,{pkg,<<"seshat">>,<<"1.0.1">>},0}]}.
 [
 {pkg_hash,[


### PR DESCRIPTION
There are no functional differences with `0.9.0`,
just a new `hex.pm` release due to certain release environment technicalities.