### PR TITLE
Expose `C_SEGMENT_SIZE_BYTES` gauges

### DIFF
--- a/src/osiris.hrl
+++ b/src/osiris.hrl
@@ -37,7 +37,7 @@
 
 -define(IS_STRING(S), is_list(S) orelse is_binary(S)).
 
--define(C_NUM_LOG_FIELDS, 5).
+-define(C_NUM_LOG_FIELDS, 7).
 
 -define(MAGIC, 5).
 %% chunk format version

--- a/src/osiris.hrl
+++ b/src/osiris.hrl
@@ -37,7 +37,7 @@
 
 -define(IS_STRING(S), is_list(S) orelse is_binary(S)).
 
--define(C_NUM_LOG_FIELDS, 7).
+-define(C_NUM_LOG_FIELDS, 6).
 
 -define(MAGIC, 5).
 %% chunk format version

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -600,13 +600,10 @@ init(#{dir := Dir,
             TailInfo = {LastChId + LastNum,
                         {LastEpoch, LastChId, LastTs}},
 
-            {InitSegBytes, InitIdxBytes} = sum_log_sizes(Config),
             counters:put(Cnt, ?C_FIRST_OFFSET, FstChId),
             counters:put(Cnt, ?C_FIRST_TIMESTAMP, FstTs),
             counters:put(Cnt, ?C_OFFSET, LastChId + LastNum - 1),
             counters:put(Cnt, ?C_SEGMENTS, NumSegments),
-            counters:put(Cnt, ?C_SEGMENT_SIZE_BYTES, InitSegBytes),
-            counters:put(Cnt, ?C_INDEX_SIZE_BYTES, InitIdxBytes),
             osiris_log_shared:set_first_chunk_id(Shared, FstChId),
             osiris_log_shared:set_last_chunk_id(Shared, LastChId),
             ?DEBUG_(Name, " next offset ~b first offset ~b",
@@ -619,6 +616,9 @@ init(#{dir := Dir,
             %% at a valid chunk we can now truncate the segment to size in
             %% case there is trailing data
             ok = file:truncate(SegFd),
+            {InitSegBytes, InitIdxBytes} = sum_log_sizes(Config),
+            counters:put(Cnt, ?C_SEGMENT_SIZE_BYTES, InitSegBytes),
+            counters:put(Cnt, ?C_INDEX_SIZE_BYTES, InitIdxBytes),
             {ok, IdxFd} = open(IdxFilename, ?FILE_OPTS_WRITE),
             {ok, IdxEof} = file:position(IdxFd, eof),
             NumChunks = (IdxEof - ?IDX_HEADER_SIZE) div ?INDEX_RECORD_SIZE_B,
@@ -944,7 +944,7 @@ truncate_to(_Name, _Range, _EpochOffsets, []) ->
     [];
 truncate_to(_Name, _Range, [], IdxFiles) ->
     %% ?????  this means the entire log is out
-    [delete_segment_from_index(I) || I <- IdxFiles],
+    _ = [delete_segment_from_index(I) || I <- IdxFiles],
     [];
 truncate_to(Name, RemoteRange, [{E, ChId} | NextEOs], IdxFiles) ->
     case find_segment_for_offset(ChId, IdxFiles) of
@@ -969,7 +969,7 @@ truncate_to(Name, RemoteRange, [{E, ChId} | NextEOs], IdxFiles) ->
                         true ->
                             %% there is no overlap, need to delete all
                             %% local segments
-                            [delete_segment_from_index(I) || I <- IdxFiles],
+                            _ = [delete_segment_from_index(I) || I <- IdxFiles],
                             [];
                         false ->
                             %% there is overlap
@@ -2273,13 +2273,16 @@ evaluate_retention(Dir, Specs) when is_binary(Dir) ->
                        fun() ->
                                IdxFiles0 = sorted_index_files(Dir),
                                {IdxFiles, DeletedBytes} =
-                                   evaluate_retention0(IdxFiles0, Specs, {0, 0}),
+                                   evaluate_retention0(IdxFiles0, Specs),
                                OffsetRange = offset_range_from_idx_files(IdxFiles),
                                FirstTs = first_timestamp_from_index_files(IdxFiles),
                                {OffsetRange, FirstTs, length(IdxFiles), DeletedBytes}
                        end),
     ?DEBUG_(<<>>," (~w) completed in ~fms", [Specs, Time/1_000]),
     Result.
+
+evaluate_retention0(IdxFiles, Specs) ->
+    evaluate_retention0(IdxFiles, Specs, {0, 0}).
 
 evaluate_retention0(IdxFiles, [], DeletedBytes) ->
     {IdxFiles, DeletedBytes};
@@ -2290,9 +2293,12 @@ evaluate_retention0(IdxFiles, [{max_age, Age} | Specs], {AccSeg, AccIdx}) ->
     {RemIdxFiles, {DelSeg, DelIdx}} = eval_age(IdxFiles, Age),
     evaluate_retention0(RemIdxFiles, Specs, {AccSeg + DelSeg, AccIdx + DelIdx}).
 
-eval_age([_] = IdxFiles, _Age) ->
-    {IdxFiles, {0, 0}};
-eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age) ->
+eval_age(IdxFiles, Age) ->
+    eval_age(IdxFiles, Age, {0, 0}).
+
+eval_age([_] = IdxFiles, _Age, Acc) ->
+    {IdxFiles, Acc};
+eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age, {AccSeg, AccIdx} = Acc) ->
     case last_timestamp_in_index_file(IdxFile) of
         {ok, Ts} ->
             Now = erlang:system_time(millisecond),
@@ -2302,18 +2308,18 @@ eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age) ->
                     %% and there are other segments available
                     %% we can delete
                     {SegSize, IdxSize} = delete_segment_from_index(IdxFile),
-                    {RemIdxFiles, {AccSeg, AccIdx}} = eval_age(IdxFiles, Age),
-                    {RemIdxFiles, {AccSeg + SegSize, AccIdx + IdxSize}};
+                    eval_age(IdxFiles, Age,
+                             {AccSeg + SegSize, AccIdx + IdxSize});
                 false ->
-                    {AllIdxFiles, {0, 0}}
+                    {AllIdxFiles, Acc}
             end;
         _Err ->
-            {AllIdxFiles, {0, 0}}
+            {AllIdxFiles, Acc}
     end;
-eval_age([], _Age) ->
+eval_age([], _Age, Acc) ->
     %% this could happen if retention is evaluated whilst
     %% a stream is being deleted
-    {[], {0, 0}}.
+    {[], Acc}.
 
 eval_max_bytes([], _) -> {[], {0, 0}};
 eval_max_bytes(IdxFiles, MaxSize) ->

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -931,10 +931,9 @@ chunk_id_index_scan0(Fd, ChunkId) ->
 delete_segment_from_index(Index) ->
     File = segment_from_index_file(Index),
     ?DEBUG("osiris_log: deleting segment ~ts", [File]),
-    SegSize = file_size_or_zero(File),
     ok = prim_file:delete(Index),
     ok = prim_file:delete(File),
-    SegSize.
+    ok.
 
 truncate_to(_Name, _Range, _EpochOffsets, []) ->
     %% the target log is empty
@@ -2308,7 +2307,8 @@ eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age, Acc) ->
                     %% the oldest timestamp is older than retention
                     %% and there are other segments available
                     %% we can delete
-                    SegSize = delete_segment_from_index(IdxFile),
+                    SegSize = file_size_or_zero(segment_from_index_file(IdxFile)),
+                    ok = delete_segment_from_index(IdxFile),
                     eval_age(IdxFiles, Age, Acc + SegSize);
                 false ->
                     {AllIdxFiles, Acc}
@@ -2341,8 +2341,9 @@ eval_max_bytes([IdxFile | Rest], Limit, Acc, AccSeg) ->
         true ->
             eval_max_bytes(Rest, Limit - Size, [IdxFile | Acc], AccSeg);
         false ->
-            Total = lists:foldl(fun(Seg, S) ->
-                                        S + delete_segment_from_index(Seg)
+            Total = lists:foldl(fun(_, S) ->
+                                        _ = delete_segment_from_index(IdxFile),
+                                        S + Size
                                 end,
                                 AccSeg,
                                 [IdxFile | Rest]),

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -85,7 +85,6 @@
 -define(C_CHUNKS, 4).
 -define(C_SEGMENTS, 5).
 -define(C_SEGMENT_SIZE_BYTES, 6).
--define(C_INDEX_SIZE_BYTES, 7).
 -define(COUNTER_FIELDS,
         [
          {offset, ?C_OFFSET, counter,
@@ -94,8 +93,7 @@
          {first_timestamp, ?C_FIRST_TIMESTAMP, counter, "First timestamp, not updated for readers"},
          {chunks, ?C_CHUNKS, counter, "Number of chunks read or written, incremented even if a reader only reads the header"},
          {segments, ?C_SEGMENTS, counter, "Number of segments"},
-         {segment_size_bytes, ?C_SEGMENT_SIZE_BYTES, counter, "Total size of all segment files in bytes"},
-         {index_size_bytes, ?C_INDEX_SIZE_BYTES, counter, "Total size of all index files in bytes"}
+         {segment_size_bytes, ?C_SEGMENT_SIZE_BYTES, counter, "Total size of all segment files in bytes"}
         ]
        ).
 
@@ -616,9 +614,8 @@ init(#{dir := Dir,
             %% at a valid chunk we can now truncate the segment to size in
             %% case there is trailing data
             ok = file:truncate(SegFd),
-            {InitSegBytes, InitIdxBytes} = sum_log_sizes(Config),
+            InitSegBytes = sum_log_sizes(Config),
             counters:put(Cnt, ?C_SEGMENT_SIZE_BYTES, InitSegBytes),
-            counters:put(Cnt, ?C_INDEX_SIZE_BYTES, InitIdxBytes),
             {ok, IdxFd} = open(IdxFilename, ?FILE_OPTS_WRITE),
             {ok, IdxEof} = file:position(IdxFd, eof),
             NumChunks = (IdxEof - ?IDX_HEADER_SIZE) div ?INDEX_RECORD_SIZE_B,
@@ -640,7 +637,6 @@ init(#{dir := Dir,
             {ok, _} = file:position(SegFd, ?LOG_HEADER_SIZE),
             counters:put(Cnt, ?C_SEGMENTS, 1),
             counters:put(Cnt, ?C_SEGMENT_SIZE_BYTES, ?LOG_HEADER_SIZE),
-            counters:put(Cnt, ?C_INDEX_SIZE_BYTES, ?IDX_HEADER_SIZE),
             %% the segment could potentially have trailing data here so we'll
             %% do a truncate just in case. The index would have been truncated
             %% earlier
@@ -934,10 +930,9 @@ delete_segment_from_index(Index) ->
     File = segment_from_index_file(Index),
     ?DEBUG("osiris_log: deleting segment ~ts", [File]),
     SegSize = file_size_or_zero(File),
-    IdxSize = file_size_or_zero(Index),
     ok = prim_file:delete(Index),
     ok = prim_file:delete(File),
-    {SegSize, IdxSize}.
+    SegSize.
 
 truncate_to(_Name, _Range, _EpochOffsets, []) ->
     %% the target log is empty
@@ -2262,43 +2257,49 @@ update_retention(Retention,
     State = State0#?MODULE{cfg = Cfg#cfg{retention = Retention}},
     trigger_retention_eval(State).
 
+-type retention_result() ::
+    #{range := range(),
+      first_timestamp := osiris:timestamp(),
+      num_remaining_segments := non_neg_integer(),
+      deleted_segment_bytes := non_neg_integer()}.
 -spec evaluate_retention(file:filename_all(), [retention_spec()]) ->
-    {range(), FirstTimestamp :: osiris:timestamp(),
-     NumRemainingFiles :: non_neg_integer(),
-     {DeletedSegBytes :: non_neg_integer(), DeletedIndexBytes :: non_neg_integer()}}.
+    retention_result().
 evaluate_retention(Dir, Specs) when is_list(Dir) ->
+    % convert to binary for faster operations later
+    % mostly in segment_from_index_file/1
     evaluate_retention(unicode:characters_to_binary(Dir), Specs);
 evaluate_retention(Dir, Specs) when is_binary(Dir) ->
     {Time, Result} = timer:tc(
                        fun() ->
                                IdxFiles0 = sorted_index_files(Dir),
-                               {IdxFiles, DeletedBytes} =
+                               {IdxFiles, DelSeg} =
                                    evaluate_retention0(IdxFiles0, Specs),
-                               OffsetRange = offset_range_from_idx_files(IdxFiles),
-                               FirstTs = first_timestamp_from_index_files(IdxFiles),
-                               {OffsetRange, FirstTs, length(IdxFiles), DeletedBytes}
+                               #{range => offset_range_from_idx_files(IdxFiles),
+                                 first_timestamp => first_timestamp_from_index_files(IdxFiles),
+                                 num_remaining_segments => length(IdxFiles),
+                                 deleted_segment_bytes => DelSeg}
                        end),
     ?DEBUG_(<<>>," (~w) completed in ~fms", [Specs, Time/1_000]),
     Result.
 
 evaluate_retention0(IdxFiles, Specs) ->
-    evaluate_retention0(IdxFiles, Specs, {0, 0}).
+    evaluate_retention0(IdxFiles, Specs, 0).
 
 evaluate_retention0(IdxFiles, [], DeletedBytes) ->
     {IdxFiles, DeletedBytes};
-evaluate_retention0(IdxFiles, [{max_bytes, MaxSize} | Specs], {AccSeg, AccIdx}) ->
-    {RemIdxFiles, {DelSeg, DelIdx}} = eval_max_bytes(IdxFiles, MaxSize),
-    evaluate_retention0(RemIdxFiles, Specs, {AccSeg + DelSeg, AccIdx + DelIdx});
-evaluate_retention0(IdxFiles, [{max_age, Age} | Specs], {AccSeg, AccIdx}) ->
-    {RemIdxFiles, {DelSeg, DelIdx}} = eval_age(IdxFiles, Age),
-    evaluate_retention0(RemIdxFiles, Specs, {AccSeg + DelSeg, AccIdx + DelIdx}).
+evaluate_retention0(IdxFiles, [{max_bytes, MaxSize} | Specs], Acc) ->
+    {RemIdxFiles, DelSeg} = eval_max_bytes(IdxFiles, MaxSize),
+    evaluate_retention0(RemIdxFiles, Specs, Acc + DelSeg);
+evaluate_retention0(IdxFiles, [{max_age, Age} | Specs], Acc) ->
+    {RemIdxFiles, DelSeg} = eval_age(IdxFiles, Age),
+    evaluate_retention0(RemIdxFiles, Specs, Acc + DelSeg).
 
 eval_age(IdxFiles, Age) ->
-    eval_age(IdxFiles, Age, {0, 0}).
+    eval_age(IdxFiles, Age, 0).
 
 eval_age([_] = IdxFiles, _Age, Acc) ->
     {IdxFiles, Acc};
-eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age, {AccSeg, AccIdx} = Acc) ->
+eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age, Acc) ->
     case last_timestamp_in_index_file(IdxFile) of
         {ok, Ts} ->
             Now = erlang:system_time(millisecond),
@@ -2307,9 +2308,8 @@ eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age, {AccSeg, AccIdx} = Acc) ->
                     %% the oldest timestamp is older than retention
                     %% and there are other segments available
                     %% we can delete
-                    {SegSize, IdxSize} = delete_segment_from_index(IdxFile),
-                    eval_age(IdxFiles, Age,
-                             {AccSeg + SegSize, AccIdx + IdxSize});
+                    SegSize = delete_segment_from_index(IdxFile),
+                    eval_age(IdxFiles, Age, Acc + SegSize);
                 false ->
                     {AllIdxFiles, Acc}
             end;
@@ -2321,7 +2321,7 @@ eval_age([], _Age, Acc) ->
     %% a stream is being deleted
     {[], Acc}.
 
-eval_max_bytes([], _) -> {[], {0, 0}};
+eval_max_bytes([], _) -> {[], 0};
 eval_max_bytes(IdxFiles, MaxSize) ->
     [Latest | Older] = lists:reverse(IdxFiles),
     eval_max_bytes(Older,
@@ -2330,25 +2330,23 @@ eval_max_bytes(IdxFiles, MaxSize) ->
                    MaxSize - file_size_or_zero(
                                segment_from_index_file(Latest)),
                    [Latest],
-                   {0, 0}).
+                   0).
 
 eval_max_bytes([], _, Acc, DeletedBytes) ->
     {Acc, DeletedBytes};
-eval_max_bytes([IdxFile | Rest], Limit, Acc, {AccSeg, AccIdx}) ->
+eval_max_bytes([IdxFile | Rest], Limit, Acc, AccSeg) ->
     SegFile = segment_from_index_file(IdxFile),
     Size = file_size(SegFile),
     case Size =< Limit of
         true ->
-            eval_max_bytes(Rest, Limit - Size, [IdxFile | Acc], {AccSeg, AccIdx});
+            eval_max_bytes(Rest, Limit - Size, [IdxFile | Acc], AccSeg);
         false ->
-            {TotalSeg, TotalIdx} =
-                lists:foldl(fun(Seg, {S, I}) ->
-                                    {SegSize, IdxSize} = delete_segment_from_index(Seg),
-                                    {S + SegSize, I + IdxSize}
-                            end,
-                            {AccSeg, AccIdx},
-                            [IdxFile | Rest]),
-            {Acc, {TotalSeg, TotalIdx}}
+            Total = lists:foldl(fun(Seg, S) ->
+                                        S + delete_segment_from_index(Seg)
+                                end,
+                                AccSeg,
+                                [IdxFile | Rest]),
+            {Acc, Total}
     end.
 
 sum_log_sizes(Config) ->
@@ -2357,12 +2355,11 @@ sum_log_sizes(Config) ->
                    #{dir := Dir} -> sorted_index_files(Dir)
                end,
     lists:foldl(
-      fun(IdxFile, {SegAcc, IdxAcc}) ->
+      fun(IdxFile, SegAcc) ->
               SegFile = segment_from_index_file(IdxFile),
-              {SegAcc + file_size_or_zero(SegFile),
-               IdxAcc + file_size_or_zero(IdxFile)}
+              SegAcc + file_size_or_zero(SegFile)
       end,
-      {0, 0},
+      0,
       IdxFiles).
 
 file_size(Path) ->
@@ -2609,7 +2606,6 @@ write_chunk(Chunk,
             counters:put(CntRef, ?C_OFFSET, NextOffset - 1),
             counters:add(CntRef, ?C_CHUNKS, 1),
             counters:add(CntRef, ?C_SEGMENT_SIZE_BYTES, Size),
-            counters:add(CntRef, ?C_INDEX_SIZE_BYTES, ?INDEX_RECORD_SIZE_B),
             maybe_set_first_offset(Next, Cfg),
             State#?MODULE{mode =
                           Write#write{tail_info = {NextOffset,
@@ -2846,7 +2842,6 @@ open_new_segment(#?MODULE{cfg = #cfg{name = Name,
     {ok, _} = file:position(IdxFd, eof),
     counters:add(Cnt, ?C_SEGMENTS, 1),
     counters:add(Cnt, ?C_SEGMENT_SIZE_BYTES, ?LOG_HEADER_SIZE),
-    counters:add(Cnt, ?C_INDEX_SIZE_BYTES, ?IDX_HEADER_SIZE),
 
     State0#?MODULE{current_file = Filename,
                    fd = Fd,
@@ -3211,15 +3206,17 @@ trigger_retention_eval(#?MODULE{cfg =
 
     %% updates first offset and first timestamp
     %% after retention has been evaluated
-    EvalFun = fun ({{FstOff, _}, FstTs, NumSegLeft, {DelSegBytes, DelIdxBytes}})
+    EvalFun = fun (#{range := {FstOff, _},
+                     first_timestamp := FstTs,
+                     num_remaining_segments := NumSegLeft,
+                     deleted_segment_bytes := DelSegBytes})
                     when is_integer(FstOff),
                          is_integer(FstTs) ->
                       osiris_log_shared:set_first_chunk_id(Shared, FstOff),
                       counters:put(Cnt, ?C_FIRST_OFFSET, FstOff),
                       counters:put(Cnt, ?C_FIRST_TIMESTAMP, FstTs),
                       counters:put(Cnt, ?C_SEGMENTS, NumSegLeft),
-                      counters:sub(Cnt, ?C_SEGMENT_SIZE_BYTES, DelSegBytes),
-                      counters:sub(Cnt, ?C_INDEX_SIZE_BYTES, DelIdxBytes);
+                      counters:sub(Cnt, ?C_SEGMENT_SIZE_BYTES, DelSegBytes);
                   (_) ->
                       ok
               end,

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -84,6 +84,8 @@
 -define(C_FIRST_TIMESTAMP, 3).
 -define(C_CHUNKS, 4).
 -define(C_SEGMENTS, 5).
+-define(C_SEGMENT_SIZE_BYTES, 6).
+-define(C_INDEX_SIZE_BYTES, 7).
 -define(COUNTER_FIELDS,
         [
          {offset, ?C_OFFSET, counter,
@@ -91,7 +93,9 @@
          {first_offset, ?C_FIRST_OFFSET, counter, "First offset, not updated for readers"},
          {first_timestamp, ?C_FIRST_TIMESTAMP, counter, "First timestamp, not updated for readers"},
          {chunks, ?C_CHUNKS, counter, "Number of chunks read or written, incremented even if a reader only reads the header"},
-         {segments, ?C_SEGMENTS, counter, "Number of segments"}
+         {segments, ?C_SEGMENTS, counter, "Number of segments"},
+         {segment_size_bytes, ?C_SEGMENT_SIZE_BYTES, counter, "Total size of all segment files in bytes"},
+         {index_size_bytes, ?C_INDEX_SIZE_BYTES, counter, "Total size of all index files in bytes"}
         ]
        ).
 
@@ -596,10 +600,13 @@ init(#{dir := Dir,
             TailInfo = {LastChId + LastNum,
                         {LastEpoch, LastChId, LastTs}},
 
+            {InitSegBytes, InitIdxBytes} = sum_log_sizes(Config),
             counters:put(Cnt, ?C_FIRST_OFFSET, FstChId),
             counters:put(Cnt, ?C_FIRST_TIMESTAMP, FstTs),
             counters:put(Cnt, ?C_OFFSET, LastChId + LastNum - 1),
             counters:put(Cnt, ?C_SEGMENTS, NumSegments),
+            counters:put(Cnt, ?C_SEGMENT_SIZE_BYTES, InitSegBytes),
+            counters:put(Cnt, ?C_INDEX_SIZE_BYTES, InitIdxBytes),
             osiris_log_shared:set_first_chunk_id(Shared, FstChId),
             osiris_log_shared:set_last_chunk_id(Shared, LastChId),
             ?DEBUG_(Name, " next offset ~b first offset ~b",
@@ -632,6 +639,8 @@ init(#{dir := Dir,
             {ok, IdxFd} = open(IdxFilename, ?FILE_OPTS_WRITE),
             {ok, _} = file:position(SegFd, ?LOG_HEADER_SIZE),
             counters:put(Cnt, ?C_SEGMENTS, 1),
+            counters:put(Cnt, ?C_SEGMENT_SIZE_BYTES, ?LOG_HEADER_SIZE),
+            counters:put(Cnt, ?C_INDEX_SIZE_BYTES, ?IDX_HEADER_SIZE),
             %% the segment could potentially have trailing data here so we'll
             %% do a truncate just in case. The index would have been truncated
             %% earlier
@@ -924,16 +933,18 @@ chunk_id_index_scan0(Fd, ChunkId) ->
 delete_segment_from_index(Index) ->
     File = segment_from_index_file(Index),
     ?DEBUG("osiris_log: deleting segment ~ts", [File]),
+    SegSize = file_size_or_zero(File),
+    IdxSize = file_size_or_zero(Index),
     ok = prim_file:delete(Index),
     ok = prim_file:delete(File),
-    ok.
+    {SegSize, IdxSize}.
 
 truncate_to(_Name, _Range, _EpochOffsets, []) ->
     %% the target log is empty
     [];
 truncate_to(_Name, _Range, [], IdxFiles) ->
     %% ?????  this means the entire log is out
-    [begin ok = delete_segment_from_index(I) end || I <- IdxFiles],
+    [delete_segment_from_index(I) || I <- IdxFiles],
     [];
 truncate_to(Name, RemoteRange, [{E, ChId} | NextEOs], IdxFiles) ->
     case find_segment_for_offset(ChId, IdxFiles) of
@@ -958,8 +969,7 @@ truncate_to(Name, RemoteRange, [{E, ChId} | NextEOs], IdxFiles) ->
                         true ->
                             %% there is no overlap, need to delete all
                             %% local segments
-                            [begin ok = delete_segment_from_index(I) end
-                             || I <- IdxFiles],
+                            [delete_segment_from_index(I) || I <- IdxFiles],
                             [];
                         false ->
                             %% there is overlap
@@ -1001,7 +1011,7 @@ truncate_to(Name, RemoteRange, [{E, ChId} | NextEOs], IdxFiles) ->
                       fun (I) ->
                               case index_file_first_offset(I) > ChId of
                                   true ->
-                                      ok = delete_segment_from_index(I),
+                                      _ = delete_segment_from_index(I),
                                       false;
                                   false ->
                                       true
@@ -2254,35 +2264,34 @@ update_retention(Retention,
 
 -spec evaluate_retention(file:filename_all(), [retention_spec()]) ->
     {range(), FirstTimestamp :: osiris:timestamp(),
-     NumRemainingFiles :: non_neg_integer()}.
+     NumRemainingFiles :: non_neg_integer(),
+     {DeletedSegBytes :: non_neg_integer(), DeletedIndexBytes :: non_neg_integer()}}.
 evaluate_retention(Dir, Specs) when is_list(Dir) ->
-    % convert to binary for faster operations later
-    % mostly in segment_from_index_file/1
     evaluate_retention(unicode:characters_to_binary(Dir), Specs);
 evaluate_retention(Dir, Specs) when is_binary(Dir) ->
-
     {Time, Result} = timer:tc(
                        fun() ->
                                IdxFiles0 = sorted_index_files(Dir),
-                               IdxFiles = evaluate_retention0(IdxFiles0, Specs),
+                               {IdxFiles, DeletedBytes} =
+                                   evaluate_retention0(IdxFiles0, Specs, {0, 0}),
                                OffsetRange = offset_range_from_idx_files(IdxFiles),
                                FirstTs = first_timestamp_from_index_files(IdxFiles),
-                               {OffsetRange, FirstTs, length(IdxFiles)}
+                               {OffsetRange, FirstTs, length(IdxFiles), DeletedBytes}
                        end),
     ?DEBUG_(<<>>," (~w) completed in ~fms", [Specs, Time/1_000]),
     Result.
 
-evaluate_retention0(IdxFiles, []) ->
-    IdxFiles;
-evaluate_retention0(IdxFiles, [{max_bytes, MaxSize} | Specs]) ->
-    RemIdxFiles = eval_max_bytes(IdxFiles, MaxSize),
-    evaluate_retention0(RemIdxFiles, Specs);
-evaluate_retention0(IdxFiles, [{max_age, Age} | Specs]) ->
-    RemIdxFiles = eval_age(IdxFiles, Age),
-    evaluate_retention0(RemIdxFiles, Specs).
+evaluate_retention0(IdxFiles, [], DeletedBytes) ->
+    {IdxFiles, DeletedBytes};
+evaluate_retention0(IdxFiles, [{max_bytes, MaxSize} | Specs], {AccSeg, AccIdx}) ->
+    {RemIdxFiles, {DelSeg, DelIdx}} = eval_max_bytes(IdxFiles, MaxSize),
+    evaluate_retention0(RemIdxFiles, Specs, {AccSeg + DelSeg, AccIdx + DelIdx});
+evaluate_retention0(IdxFiles, [{max_age, Age} | Specs], {AccSeg, AccIdx}) ->
+    {RemIdxFiles, {DelSeg, DelIdx}} = eval_age(IdxFiles, Age),
+    evaluate_retention0(RemIdxFiles, Specs, {AccSeg + DelSeg, AccIdx + DelIdx}).
 
 eval_age([_] = IdxFiles, _Age) ->
-    IdxFiles;
+    {IdxFiles, {0, 0}};
 eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age) ->
     case last_timestamp_in_index_file(IdxFile) of
         {ok, Ts} ->
@@ -2292,41 +2301,65 @@ eval_age([IdxFile | IdxFiles] = AllIdxFiles, Age) ->
                     %% the oldest timestamp is older than retention
                     %% and there are other segments available
                     %% we can delete
-                    ok = delete_segment_from_index(IdxFile),
-                    eval_age(IdxFiles, Age);
+                    {SegSize, IdxSize} = delete_segment_from_index(IdxFile),
+                    {RemIdxFiles, {AccSeg, AccIdx}} = eval_age(IdxFiles, Age),
+                    {RemIdxFiles, {AccSeg + SegSize, AccIdx + IdxSize}};
                 false ->
-                    AllIdxFiles
+                    {AllIdxFiles, {0, 0}}
             end;
         _Err ->
-            AllIdxFiles
+            {AllIdxFiles, {0, 0}}
     end;
 eval_age([], _Age) ->
     %% this could happen if retention is evaluated whilst
     %% a stream is being deleted
-    [].
+    {[], {0, 0}}.
 
-eval_max_bytes([], _) -> [];
+eval_max_bytes([], _) -> {[], {0, 0}};
 eval_max_bytes(IdxFiles, MaxSize) ->
-    [Latest|Older] = lists:reverse(IdxFiles),
+    [Latest | Older] = lists:reverse(IdxFiles),
     eval_max_bytes(Older,
                    %% for retention eval it is ok to use a file size function
                    %% that implicitly return 0 when file is not found
                    MaxSize - file_size_or_zero(
                                segment_from_index_file(Latest)),
-                   [Latest]).
+                   [Latest],
+                   {0, 0}).
 
-eval_max_bytes([], _, Acc) ->
-    Acc;
-eval_max_bytes([IdxFile | Rest], Limit, Acc) ->
+eval_max_bytes([], _, Acc, DeletedBytes) ->
+    {Acc, DeletedBytes};
+eval_max_bytes([IdxFile | Rest], Limit, Acc, {AccSeg, AccIdx}) ->
     SegFile = segment_from_index_file(IdxFile),
     Size = file_size(SegFile),
     case Size =< Limit of
         true ->
-            eval_max_bytes(Rest, Limit - Size, [IdxFile | Acc]);
+            eval_max_bytes(Rest, Limit - Size, [IdxFile | Acc], {AccSeg, AccIdx});
         false ->
-            [ok = delete_segment_from_index(Seg) || Seg <- [IdxFile | Rest]],
-            Acc
+            {TotalSeg, TotalIdx} =
+                lists:foldl(fun(Seg, {S, I}) ->
+                                    {SegSize, IdxSize} = delete_segment_from_index(Seg),
+                                    {S + SegSize, I + IdxSize}
+                            end,
+                            {AccSeg, AccIdx},
+                            [IdxFile | Rest]),
+            {Acc, {TotalSeg, TotalIdx}}
     end.
+
+%% Sums the on-disk sizes of all segment and index files in a log directory.
+%% Used once at writer/replica init to initialise the size counters.
+sum_log_sizes(Config) ->
+    IdxFiles = case Config of
+                   #{index_files := F} -> F;
+                   #{dir := Dir} -> sorted_index_files(Dir)
+               end,
+    lists:foldl(
+      fun(IdxFile, {SegAcc, IdxAcc}) ->
+              SegFile = segment_from_index_file(IdxFile),
+              {SegAcc + file_size_or_zero(SegFile),
+               IdxAcc + file_size_or_zero(IdxFile)}
+      end,
+      {0, 0},
+      IdxFiles).
 
 file_size(Path) ->
     case prim_file:read_file_info(Path) of
@@ -2571,6 +2604,8 @@ write_chunk(Chunk,
             %% update counters
             counters:put(CntRef, ?C_OFFSET, NextOffset - 1),
             counters:add(CntRef, ?C_CHUNKS, 1),
+            counters:add(CntRef, ?C_SEGMENT_SIZE_BYTES, Size),
+            counters:add(CntRef, ?C_INDEX_SIZE_BYTES, ?INDEX_RECORD_SIZE_B),
             maybe_set_first_offset(Next, Cfg),
             State#?MODULE{mode =
                           Write#write{tail_info = {NextOffset,
@@ -2806,6 +2841,8 @@ open_new_segment(#?MODULE{cfg = #cfg{name = Name,
     {ok, _} = file:position(Fd, eof),
     {ok, _} = file:position(IdxFd, eof),
     counters:add(Cnt, ?C_SEGMENTS, 1),
+    counters:add(Cnt, ?C_SEGMENT_SIZE_BYTES, ?LOG_HEADER_SIZE),
+    counters:add(Cnt, ?C_INDEX_SIZE_BYTES, ?IDX_HEADER_SIZE),
 
     State0#?MODULE{current_file = Filename,
                    fd = Fd,
@@ -3170,13 +3207,15 @@ trigger_retention_eval(#?MODULE{cfg =
 
     %% updates first offset and first timestamp
     %% after retention has been evaluated
-    EvalFun = fun ({{FstOff, _}, FstTs, NumSegLeft})
+    EvalFun = fun ({{FstOff, _}, FstTs, NumSegLeft, {DelSegBytes, DelIdxBytes}})
                     when is_integer(FstOff),
                          is_integer(FstTs) ->
                       osiris_log_shared:set_first_chunk_id(Shared, FstOff),
                       counters:put(Cnt, ?C_FIRST_OFFSET, FstOff),
                       counters:put(Cnt, ?C_FIRST_TIMESTAMP, FstTs),
-                      counters:put(Cnt, ?C_SEGMENTS, NumSegLeft);
+                      counters:put(Cnt, ?C_SEGMENTS, NumSegLeft),
+                      counters:sub(Cnt, ?C_SEGMENT_SIZE_BYTES, DelSegBytes),
+                      counters:sub(Cnt, ?C_INDEX_SIZE_BYTES, DelIdxBytes);
                   (_) ->
                       ok
               end,

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -560,6 +560,8 @@ init(#{dir := Dir,
                shared = Shared,
                filter_size = FilterSize},
     ok = maybe_fix_corrupted_files(Config),
+    IndexFiles = sorted_index_files(Config),
+    Config0 = Config#{index_files => IndexFiles},
     DefaultNextOffset = case Config of
                             #{initial_offset := IO}
                               when WriterType == acceptor ->
@@ -567,7 +569,7 @@ init(#{dir := Dir,
                             _ ->
                                 0
                         end,
-    case first_and_last_seginfos(Config) of
+    case first_and_last_seginfos(Config0) of
         none ->
             osiris_log_shared:set_first_chunk_id(Shared, DefaultNextOffset - 1),
             osiris_log_shared:set_last_chunk_id(Shared, DefaultNextOffset - 1),
@@ -614,7 +616,7 @@ init(#{dir := Dir,
             %% at a valid chunk we can now truncate the segment to size in
             %% case there is trailing data
             ok = file:truncate(SegFd),
-            InitSegBytes = sum_log_sizes(Config),
+            InitSegBytes = sum_log_sizes(IndexFiles),
             counters:put(Cnt, ?C_SEGMENT_SIZE_BYTES, InitSegBytes),
             {ok, IdxFd} = open(IdxFilename, ?FILE_OPTS_WRITE),
             {ok, IdxEof} = file:position(IdxFd, eof),
@@ -2003,9 +2005,7 @@ orphaned_segments([_Unexpected | Rem], Acc) ->
     orphaned_segments(Rem, Acc).
 
 first_and_last_seginfos(#{index_files := IdxFiles}) ->
-    first_and_last_seginfos0(IdxFiles);
-first_and_last_seginfos(#{dir := Dir}) ->
-    first_and_last_seginfos0(sorted_index_files(Dir)).
+    first_and_last_seginfos0(IdxFiles).
 
 first_and_last_seginfos0([]) ->
     none;
@@ -2349,11 +2349,7 @@ eval_max_bytes([IdxFile | Rest], Limit, Acc, AccSeg) ->
             {Acc, Total}
     end.
 
-sum_log_sizes(Config) ->
-    IdxFiles = case Config of
-                   #{index_files := F} -> F;
-                   #{dir := Dir} -> sorted_index_files(Dir)
-               end,
+sum_log_sizes(IdxFiles) ->
     lists:foldl(
       fun(IdxFile, SegAcc) ->
               SegFile = segment_from_index_file(IdxFile),

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -2345,9 +2345,11 @@ eval_max_bytes([IdxFile | Rest], Limit, Acc, AccSeg) ->
         true ->
             eval_max_bytes(Rest, Limit - Size, [IdxFile | Acc], AccSeg);
         false ->
-            Total = lists:foldl(fun(_, S) ->
-                                        _ = delete_segment_from_index(IdxFile),
-                                        S + Size
+            Total = lists:foldl(fun(Seg, S) ->
+                                        SegSize = file_size_or_zero(
+                                                    segment_from_index_file(Seg)),
+                                        _ = delete_segment_from_index(Seg),
+                                        S + SegSize
                                 end,
                                 AccSeg,
                                 [IdxFile | Rest]),

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -2345,8 +2345,6 @@ eval_max_bytes([IdxFile | Rest], Limit, Acc, {AccSeg, AccIdx}) ->
             {Acc, {TotalSeg, TotalIdx}}
     end.
 
-%% Sums the on-disk sizes of all segment and index files in a log directory.
-%% Used once at writer/replica init to initialise the size counters.
 sum_log_sizes(Config) ->
     IdxFiles = case Config of
                    #{index_files := F} -> F;

--- a/src/osiris_retention.erl
+++ b/src/osiris_retention.erl
@@ -97,7 +97,7 @@ evaluate_retention({eval, Pid, Name, Dir, Specs, Fun} = Eval, State) ->
     end.
 
 schedule({eval, _Pid, Name, _Dir, Specs, _Fun} = Eval,
-         {_, _, NumSegmentRemaining},
+         {_, _, NumSegmentRemaining, _},
          #state{scheduled = Scheduled0} = State) ->
     %% we need to check the scheduled map even if the current specs do not
     %% include max_age as the retention config could have changed

--- a/src/osiris_retention.erl
+++ b/src/osiris_retention.erl
@@ -97,7 +97,7 @@ evaluate_retention({eval, Pid, Name, Dir, Specs, Fun} = Eval, State) ->
     end.
 
 schedule({eval, _Pid, Name, _Dir, Specs, _Fun} = Eval,
-         {_, _, NumSegmentRemaining, _},
+         #{num_remaining_segments := NumSegmentRemaining},
          #state{scheduled = Scheduled0} = State) ->
     %% we need to check the scheduled map even if the current specs do not
     %% include max_age as the retention config could have changed

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -59,6 +59,7 @@ all_tests() ->
      replica_unknown_command,
      diverged_replica,
      retention,
+     retention_size_counters,
      retention_max_age_eventually,
      retention_max_age_update_retention,
      retention_max_age_noproc,
@@ -1218,6 +1219,37 @@ retention(Config) ->
     ct:pal("PRE WILD"),
     [_] = wildcard(Wc),
     ct:pal("POST WILD"),
+    osiris:stop_cluster(Conf1),
+    ok.
+
+retention_size_counters(Config) ->
+    %% Verify that size counters are decremented through the full
+    %% osiris_retention:eval -> evaluate_retention -> EvalFun -> counters:sub path.
+    %% Use a very large max_bytes so no retention fires during writes, then
+    %% tighten it so that update_retention must delete segments.
+    Name = ?config(cluster_name, Config),
+    SegSize = 100 * 1000,
+    Conf0 =
+        #{name => Name,
+          epoch => 1,
+          leader_node => node(),
+          retention => [{max_bytes, SegSize * 100}],
+          max_segment_size_bytes => SegSize,
+          replica_nodes => []},
+    {ok, #{leader_pid := Leader} = Conf1} = osiris:start_cluster(Conf0),
+    %% ~500KB across multiple segments
+    write_n(Leader, 1000, 0, 500 * 8, #{}),
+    Key = {osiris_writer, Name},
+    #{segment_size_bytes := SegBefore} =
+        osiris_counters:counters(Key, [segment_size_bytes]),
+    %% Tighten retention to one segment — must delete previously retained segments.
+    ok = osiris:update_retention(Leader, [{max_bytes, SegSize}]),
+    await_condition(
+        fun() ->
+            #{segment_size_bytes := S} =
+                osiris_counters:counters(Key, [segment_size_bytes]),
+            S < SegBefore
+        end, 200, 50),
     osiris:stop_cluster(Conf1),
     ok.
 

--- a/test/osiris_SUITE.erl
+++ b/test/osiris_SUITE.erl
@@ -1223,10 +1223,6 @@ retention(Config) ->
     ok.
 
 retention_size_counters(Config) ->
-    %% Verify that size counters are decremented through the full
-    %% osiris_retention:eval -> evaluate_retention -> EvalFun -> counters:sub path.
-    %% Use a very large max_bytes so no retention fires during writes, then
-    %% tighten it so that update_retention must delete segments.
     Name = ?config(cluster_name, Config),
     SegSize = 100 * 1000,
     Conf0 =
@@ -1237,12 +1233,10 @@ retention_size_counters(Config) ->
           max_segment_size_bytes => SegSize,
           replica_nodes => []},
     {ok, #{leader_pid := Leader} = Conf1} = osiris:start_cluster(Conf0),
-    %% ~500KB across multiple segments
     write_n(Leader, 1000, 0, 500 * 8, #{}),
     Key = {osiris_writer, Name},
     #{segment_size_bytes := SegBefore} =
         osiris_counters:counters(Key, [segment_size_bytes]),
-    %% Tighten retention to one segment — must delete previously retained segments.
     ok = osiris:update_retention(Leader, [{max_bytes, SegSize}]),
     await_condition(
         fun() ->

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -278,7 +278,6 @@ size_counters_after_retention_max_bytes(Config) ->
     SegBefore = counter_get(Cnt, segment_size_bytes),
     IdxBefore = counter_get(Cnt, index_size_bytes),
     ok = osiris_log:close(Log0),
-    %% reload so counters reflect files on disk
     Log1 = osiris_log:init(Conf#{dir => LDir}),
     Cnt1 = osiris_log:counters_ref(Log1),
     SegInit = counter_get(Cnt1, segment_size_bytes),
@@ -286,7 +285,6 @@ size_counters_after_retention_max_bytes(Config) ->
     ?assertEqual(SegBefore, SegInit),
     ?assertEqual(IdxBefore, IdxInit),
     ok = osiris_log:close(Log1),
-    %% retention should delete segments and reduce counters
     {_, _, _, {DelSeg, DelIdx}} =
         osiris_log:evaluate_retention(LDir, [{max_bytes, 1500 * 100}]),
     ?assert(DelSeg > 0),
@@ -314,7 +312,6 @@ size_counters_after_retention_max_age(Config) ->
     SegInit = counter_get(Cnt1, segment_size_bytes),
     IdxInit = counter_get(Cnt1, index_size_bytes),
     ok = osiris_log:close(Log1),
-    %% max_age of 1000ms: all chunks are 2000ms old so at least one segment deleted
     {_, _, _, {DelSeg, DelIdx}} =
         osiris_log:evaluate_retention(LDir, [{max_bytes, 100000000}, {max_age, 1000}]),
     ?assert(DelSeg > 0),
@@ -1770,7 +1767,7 @@ evaluate_retention_max_bytes(Config) ->
     %% this should delete at least one segment
     Spec = {max_bytes, 1500 * 100},
     {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, [Spec]),
-    %% idempotency check: range and segment count must be stable; deleted bytes differ
+    %% idempotency check
     {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, [Spec]),
     SegFiles =
         filelib:wildcard(
@@ -3230,8 +3227,6 @@ recv(Socket, Expected, Acc) ->
             Other
     end.
 
-%% Returns the value of a named counter field from a raw counters ref.
-%% Looks up the slot position from osiris_log:counter_fields/0.
 counter_get(Cnt, Name) ->
     Fields = osiris_log:counter_fields(),
     {Name, Pos, _, _} = lists:keyfind(Name, 1, Fields),

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -233,7 +233,6 @@ size_counters_fresh_log(Config) ->
     S0 = osiris_log:init(Conf),
     Cnt = osiris_log:counters_ref(S0),
     ?assertEqual(?LOG_HEADER_SIZE, counter_get(Cnt, segment_size_bytes)),
-    ?assertEqual(?IDX_HEADER_SIZE, counter_get(Cnt, index_size_bytes)),
     ok = osiris_log:close(S0),
     ok.
 
@@ -242,10 +241,8 @@ size_counters_after_write(Config) ->
     S0 = osiris_log:init(Conf),
     Cnt = osiris_log:counters_ref(S0),
     SegBefore = counter_get(Cnt, segment_size_bytes),
-    IdxBefore = counter_get(Cnt, index_size_bytes),
     S1 = osiris_log:write([<<"hello">>], S0),
     ?assert(counter_get(Cnt, segment_size_bytes) > SegBefore),
-    ?assertEqual(IdxBefore + ?INDEX_RECORD_SIZE_B, counter_get(Cnt, index_size_bytes)),
     ok = osiris_log:close(S1),
     ok.
 
@@ -256,12 +253,10 @@ size_counters_restart(Config) ->
     Log0 = seed_log(Conf#{dir => LDir}, EpochChunks, Config),
     Cnt0 = osiris_log:counters_ref(Log0),
     SegBytes = counter_get(Cnt0, segment_size_bytes),
-    IdxBytes = counter_get(Cnt0, index_size_bytes),
     ok = osiris_log:close(Log0),
     Log1 = osiris_log:init(Conf#{dir => LDir}),
     Cnt1 = osiris_log:counters_ref(Log1),
     ?assertEqual(SegBytes, counter_get(Cnt1, segment_size_bytes)),
-    ?assertEqual(IdxBytes, counter_get(Cnt1, index_size_bytes)),
     ok = osiris_log:close(Log1),
     ok.
 
@@ -276,23 +271,18 @@ size_counters_after_retention_max_bytes(Config) ->
                     EpochChunks, Config),
     Cnt = osiris_log:counters_ref(Log0),
     SegBefore = counter_get(Cnt, segment_size_bytes),
-    IdxBefore = counter_get(Cnt, index_size_bytes),
     ok = osiris_log:close(Log0),
     Log1 = osiris_log:init(Conf#{dir => LDir}),
     Cnt1 = osiris_log:counters_ref(Log1),
     SegInit = counter_get(Cnt1, segment_size_bytes),
-    IdxInit = counter_get(Cnt1, index_size_bytes),
     ?assertEqual(SegBefore, SegInit),
-    ?assertEqual(IdxBefore, IdxInit),
     ok = osiris_log:close(Log1),
-    {_, _, _, {DelSeg, DelIdx}} =
+    #{deleted_segment_bytes := DelSeg} =
         osiris_log:evaluate_retention(LDir, [{max_bytes, 1500 * 100}]),
     ?assert(DelSeg > 0),
-    ?assert(DelIdx > 0),
     Log2 = osiris_log:init(Conf#{dir => LDir}),
     Cnt2 = osiris_log:counters_ref(Log2),
     ?assertEqual(SegInit - DelSeg, counter_get(Cnt2, segment_size_bytes)),
-    ?assertEqual(IdxInit - DelIdx, counter_get(Cnt2, index_size_bytes)),
     ok = osiris_log:close(Log2),
     ok.
 
@@ -310,16 +300,13 @@ size_counters_after_retention_max_age(Config) ->
     Log1 = osiris_log:init(Conf#{dir => LDir}),
     Cnt1 = osiris_log:counters_ref(Log1),
     SegInit = counter_get(Cnt1, segment_size_bytes),
-    IdxInit = counter_get(Cnt1, index_size_bytes),
     ok = osiris_log:close(Log1),
-    {_, _, _, {DelSeg, DelIdx}} =
+    #{deleted_segment_bytes := DelSeg} =
         osiris_log:evaluate_retention(LDir, [{max_bytes, 100000000}, {max_age, 1000}]),
     ?assert(DelSeg > 0),
-    ?assert(DelIdx > 0),
     Log2 = osiris_log:init(Conf#{dir => LDir}),
     Cnt2 = osiris_log:counters_ref(Log2),
     ?assertEqual(SegInit - DelSeg, counter_get(Cnt2, segment_size_bytes)),
-    ?assertEqual(IdxInit - DelIdx, counter_get(Cnt2, index_size_bytes)),
     ok = osiris_log:close(Log2),
     ok.
 
@@ -1766,9 +1753,15 @@ evaluate_retention_max_bytes(Config) ->
     osiris_log:close(Log),
     %% this should delete at least one segment
     Spec = {max_bytes, 1500 * 100},
-    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, [Spec]),
+    #{range := OffRange,
+      first_timestamp := FstTs,
+      num_remaining_segments := NumSeg} =
+        osiris_log:evaluate_retention(LDir, [Spec]),
     %% idempotency check
-    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, [Spec]),
+    #{range := OffRange,
+      first_timestamp := FstTs,
+      num_remaining_segments := NumSeg} =
+        osiris_log:evaluate_retention(LDir, [Spec]),
     SegFiles =
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
@@ -1810,9 +1803,15 @@ evaluate_retention_max_age(Config) ->
     %% this should delete at least one segment as all chunks should be older
     %% than the retention of 1000ms; max_bytes shouldn't affect the result
     Spec = [{max_bytes, 100000000}, {max_age, 1000}],
-    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, Spec),
+    #{range := OffRange,
+      first_timestamp := FstTs,
+      num_remaining_segments := NumSeg} =
+        osiris_log:evaluate_retention(LDir, Spec),
     %% idempotency check: range and segment count must be stable; deleted bytes differ
-    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, Spec),
+    #{range := OffRange,
+      first_timestamp := FstTs,
+      num_remaining_segments := NumSeg} =
+        osiris_log:evaluate_retention(LDir, Spec),
     SegFiles =
         filelib:wildcard(
             filename:join(LDir, "*.segment")),

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -34,6 +34,11 @@ all_tests() ->
      init_recover,
      init_recover_with_writers,
      init_with_lower_epoch,
+     size_counters_fresh_log,
+     size_counters_after_write,
+     size_counters_restart,
+     size_counters_after_retention_max_bytes,
+     size_counters_after_retention_max_age,
      write_batch,
      write_with_filter_attach_next,
      write_batch_with_filter,
@@ -221,6 +226,104 @@ init_with_lower_epoch(Config) ->
     %% lower is not ok
     ?assertException(exit, {invalid_epoch, _, _},
                      osiris_log:init(Conf#{epoch => 0})),
+    ok.
+
+size_counters_fresh_log(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    S0 = osiris_log:init(Conf),
+    Cnt = osiris_log:counters_ref(S0),
+    ?assertEqual(?LOG_HEADER_SIZE, counter_get(Cnt, segment_size_bytes)),
+    ?assertEqual(?IDX_HEADER_SIZE, counter_get(Cnt, index_size_bytes)),
+    ok = osiris_log:close(S0),
+    ok.
+
+size_counters_after_write(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    S0 = osiris_log:init(Conf),
+    Cnt = osiris_log:counters_ref(S0),
+    SegBefore = counter_get(Cnt, segment_size_bytes),
+    IdxBefore = counter_get(Cnt, index_size_bytes),
+    S1 = osiris_log:write([<<"hello">>], S0),
+    ?assert(counter_get(Cnt, segment_size_bytes) > SegBefore),
+    ?assertEqual(IdxBefore + ?INDEX_RECORD_SIZE_B, counter_get(Cnt, index_size_bytes)),
+    ok = osiris_log:close(S1),
+    ok.
+
+size_counters_restart(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    LDir = ?config(leader_dir, Config),
+    EpochChunks = [{1, [crypto:strong_rand_bytes(512) || _ <- lists:seq(1, 10)]}],
+    Log0 = seed_log(Conf#{dir => LDir}, EpochChunks, Config),
+    Cnt0 = osiris_log:counters_ref(Log0),
+    SegBytes = counter_get(Cnt0, segment_size_bytes),
+    IdxBytes = counter_get(Cnt0, index_size_bytes),
+    ok = osiris_log:close(Log0),
+    Log1 = osiris_log:init(Conf#{dir => LDir}),
+    Cnt1 = osiris_log:counters_ref(Log1),
+    ?assertEqual(SegBytes, counter_get(Cnt1, segment_size_bytes)),
+    ?assertEqual(IdxBytes, counter_get(Cnt1, index_size_bytes)),
+    ok = osiris_log:close(Log1),
+    ok.
+
+size_counters_after_retention_max_bytes(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    LDir = ?config(leader_dir, Config),
+    Data = crypto:strong_rand_bytes(1500),
+    EpochChunks =
+        [begin {1, [Data || _ <- lists:seq(1, 50)]} end
+         || _ <- lists:seq(1, 20)],
+    Log0 = seed_log(Conf#{dir => LDir, max_segment_size_bytes => 1000 * 1000},
+                    EpochChunks, Config),
+    Cnt = osiris_log:counters_ref(Log0),
+    SegBefore = counter_get(Cnt, segment_size_bytes),
+    IdxBefore = counter_get(Cnt, index_size_bytes),
+    ok = osiris_log:close(Log0),
+    %% reload so counters reflect files on disk
+    Log1 = osiris_log:init(Conf#{dir => LDir}),
+    Cnt1 = osiris_log:counters_ref(Log1),
+    SegInit = counter_get(Cnt1, segment_size_bytes),
+    IdxInit = counter_get(Cnt1, index_size_bytes),
+    ?assertEqual(SegBefore, SegInit),
+    ?assertEqual(IdxBefore, IdxInit),
+    ok = osiris_log:close(Log1),
+    %% retention should delete segments and reduce counters
+    {_, _, _, {DelSeg, DelIdx}} =
+        osiris_log:evaluate_retention(LDir, [{max_bytes, 1500 * 100}]),
+    ?assert(DelSeg > 0),
+    ?assert(DelIdx > 0),
+    Log2 = osiris_log:init(Conf#{dir => LDir}),
+    Cnt2 = osiris_log:counters_ref(Log2),
+    ?assertEqual(SegInit - DelSeg, counter_get(Cnt2, segment_size_bytes)),
+    ?assertEqual(IdxInit - DelIdx, counter_get(Cnt2, index_size_bytes)),
+    ok = osiris_log:close(Log2),
+    ok.
+
+size_counters_after_retention_max_age(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    LDir = ?config(leader_dir, Config),
+    Data = crypto:strong_rand_bytes(1500),
+    Ts = now_ms() - 2000,
+    EpochChunks =
+        [begin {1, Ts, [Data || _ <- lists:seq(1, 50)]} end
+         || _ <- lists:seq(1, 20)],
+    Log0 = seed_log(Conf#{dir => LDir, max_segment_size_bytes => 1000 * 1000},
+                    EpochChunks, Config),
+    ok = osiris_log:close(Log0),
+    Log1 = osiris_log:init(Conf#{dir => LDir}),
+    Cnt1 = osiris_log:counters_ref(Log1),
+    SegInit = counter_get(Cnt1, segment_size_bytes),
+    IdxInit = counter_get(Cnt1, index_size_bytes),
+    ok = osiris_log:close(Log1),
+    %% max_age of 1000ms: all chunks are 2000ms old so at least one segment deleted
+    {_, _, _, {DelSeg, DelIdx}} =
+        osiris_log:evaluate_retention(LDir, [{max_bytes, 100000000}, {max_age, 1000}]),
+    ?assert(DelSeg > 0),
+    ?assert(DelIdx > 0),
+    Log2 = osiris_log:init(Conf#{dir => LDir}),
+    Cnt2 = osiris_log:counters_ref(Log2),
+    ?assertEqual(SegInit - DelSeg, counter_get(Cnt2, segment_size_bytes)),
+    ?assertEqual(IdxInit - DelIdx, counter_get(Cnt2, index_size_bytes)),
+    ok = osiris_log:close(Log2),
     ok.
 
 write_batch(Config) ->
@@ -1666,9 +1769,9 @@ evaluate_retention_max_bytes(Config) ->
     osiris_log:close(Log),
     %% this should delete at least one segment
     Spec = {max_bytes, 1500 * 100},
-    Range = osiris_log:evaluate_retention(LDir, [Spec]),
-    %% idempotency check
-    Range = osiris_log:evaluate_retention(LDir, [Spec]),
+    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, [Spec]),
+    %% idempotency check: range and segment count must be stable; deleted bytes differ
+    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, [Spec]),
     SegFiles =
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
@@ -1710,9 +1813,9 @@ evaluate_retention_max_age(Config) ->
     %% this should delete at least one segment as all chunks should be older
     %% than the retention of 1000ms; max_bytes shouldn't affect the result
     Spec = [{max_bytes, 100000000}, {max_age, 1000}],
-    Range = osiris_log:evaluate_retention(LDir, Spec),
-    %% idempotency
-    Range = osiris_log:evaluate_retention(LDir, Spec),
+    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, Spec),
+    %% idempotency check: range and segment count must be stable; deleted bytes differ
+    {OffRange, FstTs, NumSeg, _} = osiris_log:evaluate_retention(LDir, Spec),
     SegFiles =
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
@@ -3126,3 +3229,10 @@ recv(Socket, Expected, Acc) ->
         Other ->
             Other
     end.
+
+%% Returns the value of a named counter field from a raw counters ref.
+%% Looks up the slot position from osiris_log:counter_fields/0.
+counter_get(Cnt, Name) ->
+    Fields = osiris_log:counter_fields(),
+    {Name, Pos, _, _} = lists:keyfind(Name, 1, Fields),
+    counters:get(Cnt, Pos).


### PR DESCRIPTION
## What
Add both metrics for C_SEGMENT_SIZE_BYTES so we can enable on Management UI and Prometheus.

## How
- 1 new fields
- Increment on each write
- Decrement after each retention eval cycle
- Calculate the initial sizes doing `stat` at each file at `init`



#### Below is AI-generated
### Benchmark with Mac Book M3 Max PRO (32GB RAM 10-4 CPU)

| Phase                                            | Result                                                                               |
| ------------------------------------------------ | ------------------------------------------------------------------------------------ |
| **Fill** (50 GB, 101 segments)                   | ~1.25 GB/s sustained, stable across all segments                                     |
| **Restart** (101 segments)                       | 9 ms avg (16 ms cold, 6 ms warm) — `sum_log_sizes` is 101 × 2 stat calls, negligible |
| **Retention run 1** (51 segments deleted, 25 GB) | 406 ms                                                                               |
| **Retention runs 2–5** (idempotent, 0 deletes)   | 2–3 ms                                                                               |

The 406 ms on the first retention run is the actual file deletion of 51 segments. Runs 2–5 (index scan only, nothing to delete) are 2–3 ms regardless of how many segments remain — that confirms the O(remaining) scan is cheap at this scale.

At 100 GB you'd expect ~800 ms for a full 50% delete run, and the same 2–4 ms for idempotent evaluations. Nothing alarming.

Closes #161 