### PR TITLE
Use binary search to locate offsets/timestamps in index files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,13 @@ DEPS = gen_batch_server seshat
 
 # TEST_DEPS=eunit_formatters looking_glass
 dep_tls_gen = git https://github.com/rabbitmq/tls-gen.git main
-TEST_DEPS=eunit_formatters tls_gen
+dep_proper = hex 1.4.0
+TEST_DEPS=eunit_formatters tls_gen proper
 
 dep_looking_glass = git https://github.com/rabbitmq/looking-glass.git master
 # PLT_APPS += eunit syntax_tools erts kernel stdlib common_test inets ssh ssl meck looking_glass gen_batch_server inet_tcp_proxy
 
 DIALYZER_OPTS += --src -r test -Wunmatched_returns -Werror_handling
-PLT_APPS += seshat ssl eunit common_test
+PLT_APPS += seshat ssl eunit common_test proper
 EUNIT_OPTS = no_tty, {report, {eunit_progress, [colored, profile]}}
 include $(if $(ERLANG_MK_FILENAME),$(ERLANG_MK_FILENAME),erlang.mk)

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -2471,6 +2471,59 @@ idx_lin_scan(<<IdxRecordBin:?INDEX_RECORD_SIZE_B/binary, Rem/binary>>, Fun, Acc0
             Ret
     end.
 
+%% Block binary search: binary search over block boundaries to find the
+%% target block, then linear scan within that block. O(log2(n/B) + B) where
+%% B = ?SKIP_SEARCH_JUMP. Uses the same callback interface as idx_skip_search.
+%%
+%% NumRecords is the number of index records in the file (excluding header).
+idx_block_binary_search(Fd, NumRecords, Fun, Acc0) ->
+    NumBlocks = (NumRecords + ?SKIP_SEARCH_JUMP - 1) div ?SKIP_SEARCH_JUMP,
+    BlockIdx = idx_bbs_find_block(Fd, 0, NumBlocks - 1, Fun, Acc0, NumRecords),
+    BlockStart = BlockIdx * ?SKIP_SEARCH_JUMP,
+    BlockEnd = min(BlockStart + ?SKIP_SEARCH_JUMP, NumRecords),
+    ReadSize = (BlockEnd - BlockStart) * ?INDEX_RECORD_SIZE_B,
+    ReadPos = ?IDX_HEADER_SIZE + BlockStart * ?INDEX_RECORD_SIZE_B,
+    case file:pread(Fd, ReadPos, ReadSize) of
+        {ok, Data} ->
+            case idx_lin_scan(Data, Fun, Acc0) of
+                {continue, Acc} -> Acc;
+                {return, Acc} -> Acc
+            end;
+        eof ->
+            Acc0
+    end.
+
+%% Binary search over block boundaries. Returns the index of the block
+%% that should contain the target (the last block whose first record
+%% does not overshoot the target).
+idx_bbs_find_block(_Fd, Lo, Hi, _Fun, _Acc, _NumRecords) when Lo > Hi ->
+    max(0, Lo - 1);
+idx_bbs_find_block(Fd, Lo, Hi, Fun, Acc0, NumRecords) ->
+    Mid = (Lo + Hi) div 2,
+    RecIdx = Mid * ?SKIP_SEARCH_JUMP,
+    case RecIdx >= NumRecords of
+        true ->
+            idx_bbs_find_block(Fd, Lo, Mid - 1, Fun, Acc0, NumRecords);
+        false ->
+            Pos = ?IDX_HEADER_SIZE + RecIdx * ?INDEX_RECORD_SIZE_B,
+            case idx_read_at(Fd, Pos) of
+                {ok, IdxRecordBin} ->
+                    case Fun(peek, IdxRecordBin, Acc0) of
+                        {scan, _} ->
+                            %% Target is before this block
+                            idx_bbs_find_block(Fd, Lo, Mid - 1, Fun, Acc0, NumRecords);
+                        {continue, _} ->
+                            %% Target is at or after this block
+                            idx_bbs_find_block(Fd, Mid + 1, Hi, Fun, Acc0, NumRecords);
+                        {return, _} ->
+                            %% Exact match at block boundary
+                            Mid
+                    end;
+                _ ->
+                    idx_bbs_find_block(Fd, Lo, Mid - 1, Fun, Acc0, NumRecords)
+            end
+    end.
+
 segment_from_index_file(IdxFile) when is_list(IdxFile) ->
     unicode:characters_to_list(string:replace(IdxFile, ".index", ".segment", trailing));
 segment_from_index_file(IdxFile) when is_binary(IdxFile) ->
@@ -2835,10 +2888,13 @@ offset_idx_scan(Name, Offset, #seg_info{index = IndexFile} = SegmentInfo) ->
                              {ok, IdxFd} = open(IndexFile,
                                                 [read, raw, binary]),
                              _ = file:advise(IdxFd, 0, 0, random),
+                             {ok, EofPos} = file:position(IdxFd, eof),
+                             NumRecords = (EofPos - ?IDX_HEADER_SIZE)
+                                          div ?INDEX_RECORD_SIZE_B,
                              {Offset, SearchResult} =
-                                 idx_skip_search(IdxFd, ?IDX_HEADER_SIZE,
-                                                 fun offset_search_fun/3,
-                                                 {Offset, not_found}),
+                                 idx_block_binary_search(IdxFd, NumRecords,
+                                                         fun offset_search_fun/3,
+                                                         {Offset, not_found}),
                              ok = file:close(IdxFd),
                              SearchResult
                      end
@@ -2871,10 +2927,13 @@ open(File, Options) ->
 chunk_location_for_timestamp(Idx, Ts) ->
     {ok, IdxFd} = open(Idx, [read, raw, binary]),
     _ = file:advise(IdxFd, 0, 0, random),
+    {ok, EofPos} = file:position(IdxFd, eof),
+    NumRecords = (EofPos - ?IDX_HEADER_SIZE)
+                 div ?INDEX_RECORD_SIZE_B,
     {Ts, {ChunkId, _Timestamp, _Epoch, FilePos}} =
-        idx_skip_search(IdxFd, ?IDX_HEADER_SIZE,
-                        fun timestamp_search_fun/3,
-                        {Ts, not_found}),
+        idx_block_binary_search(IdxFd, NumRecords,
+                                fun timestamp_search_fun/3,
+                                {Ts, not_found}),
     ok = file:close(IdxFd),
     {ChunkId, FilePos}.
 

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -72,7 +72,11 @@
          index_files_unsorted/1,
          make_chunk/7,
          orphaned_segments/1,
-         read_header0/1
+         read_header0/1,
+         idx_skip_search/4,
+         idx_block_binary_search/4,
+         offset_search_fun/3,
+         timestamp_search_fun/3
         ]).
 
 % maximum size of a segment in bytes

--- a/test/osiris_log_prop_SUITE.erl
+++ b/test/osiris_log_prop_SUITE.erl
@@ -1,0 +1,159 @@
+-module(osiris_log_prop_SUITE).
+-compile([export_all, nowarn_export_all]).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include("src/osiris.hrl").
+
+all() -> [
+    prop_block_binary_search_offset_matches_skip_search,
+    prop_block_binary_search_timestamp_matches_skip_search
+].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(TC, Config) ->
+    PrivDir = ?config(priv_dir, Config),
+    TcDir = filename:join(PrivDir, atom_to_list(TC)),
+    ok = filelib:ensure_dir(filename:join(TcDir, "dummy")),
+    persistent_term:put({?MODULE, test_dir}, TcDir),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    persistent_term:erase({?MODULE, test_dir}),
+    ok.
+
+%% --- Properties ---
+
+-dialyzer([{nowarn_function, prop_block_binary_search_offset_matches_skip_search/1},
+           {nowarn_function, prop_block_binary_search_timestamp_matches_skip_search/1}]).
+
+prop_block_binary_search_offset_matches_skip_search(_Config) ->
+    true = proper:quickcheck(
+             prop_offset_search(),
+             [{numtests, 500}, {to_file, user}]).
+
+prop_block_binary_search_timestamp_matches_skip_search(_Config) ->
+    true = proper:quickcheck(
+             prop_timestamp_search(),
+             [{numtests, 500}, {to_file, user}]).
+
+%% --- Property definitions ---
+
+prop_offset_search() ->
+    ?FORALL({Deltas, StartOffset, TargetFraction},
+            {non_empty(list(range(1, 10))), range(1, 100), float(0.0, 1.0)},
+            begin
+                Offsets = prefix_sum(Deltas, StartOffset),
+                NumChunks = length(Offsets),
+                MaxOffset = lists:last(Offsets),
+                Target = trunc(MaxOffset * TargetFraction),
+                IdxFile = write_index_file(Offsets),
+                try
+                    compare_offset_search(IdxFile, Target, NumChunks)
+                after
+                    file:delete(IdxFile)
+                end
+            end).
+
+prop_timestamp_search() ->
+    ?FORALL({Deltas, StartTs, TargetFraction},
+            {non_empty(list(range(1, 5000))), range(1, 1000000000000), float(0.0, 1.0)},
+            begin
+                Timestamps = prefix_sum(Deltas, StartTs),
+                NumChunks = length(Timestamps),
+                MaxTs = lists:last(Timestamps),
+                MinTs = hd(Timestamps),
+                Target = MinTs + trunc((MaxTs - MinTs) * TargetFraction),
+                IdxFile = write_index_file_with_timestamps(NumChunks, Timestamps),
+                try
+                    compare_timestamp_search(IdxFile, Target, NumChunks)
+                after
+                    file:delete(IdxFile)
+                end
+            end).
+
+%% --- Comparison functions ---
+
+compare_offset_search(IdxFile, Target, NumRecords) ->
+    {ok, Fd} = file:open(IdxFile, [read, raw, binary]),
+    SkipResult = osiris_log:idx_skip_search(
+                   Fd, ?IDX_HEADER_SIZE,
+                   fun osiris_log:offset_search_fun/3,
+                   {Target, not_found}),
+    _ = file:position(Fd, bof),
+    BlockResult = osiris_log:idx_block_binary_search(
+                    Fd, NumRecords,
+                    fun osiris_log:offset_search_fun/3,
+                    {Target, not_found}),
+    ok = file:close(Fd),
+    case SkipResult =:= BlockResult of
+        true ->
+            true;
+        false ->
+            ct:pal("MISMATCH offset=~p skip=~p block=~p",
+                   [Target, SkipResult, BlockResult]),
+            false
+    end.
+
+compare_timestamp_search(IdxFile, Target, NumRecords) ->
+    {ok, Fd} = file:open(IdxFile, [read, raw, binary]),
+    SkipResult = osiris_log:idx_skip_search(
+                   Fd, ?IDX_HEADER_SIZE,
+                   fun osiris_log:timestamp_search_fun/3,
+                   {Target, not_found}),
+    _ = file:position(Fd, bof),
+    BlockResult = osiris_log:idx_block_binary_search(
+                    Fd, NumRecords,
+                    fun osiris_log:timestamp_search_fun/3,
+                    {Target, not_found}),
+    ok = file:close(Fd),
+    case SkipResult =:= BlockResult of
+        true ->
+            true;
+        false ->
+            ct:pal("MISMATCH ts=~p skip=~p block=~p",
+                   [Target, SkipResult, BlockResult]),
+            false
+    end.
+
+%% --- Generators / helpers ---
+
+prefix_sum(Deltas, Start) ->
+    {Sums, _} = lists:mapfoldl(fun(D, Acc) -> {Acc, Acc + D} end, Start, Deltas),
+    Sums.
+
+write_index_file(Offsets) ->
+    File = tmp_idx_file(),
+    Header = <<"OSII", 1:32/unsigned>>,
+    Records = [<<Offset:64/unsigned,
+                 Offset:64/signed,
+                 1:64/unsigned,
+                 0:32/unsigned,
+                 0:8/unsigned>> || Offset <- Offsets],
+    ok = file:write_file(File, [Header | Records]),
+    File.
+
+write_index_file_with_timestamps(N, Timestamps) ->
+    File = tmp_idx_file(),
+    Header = <<"OSII", 1:32/unsigned>>,
+    Offsets = lists:seq(0, N - 1),
+    Records = lists:zipwith(
+                fun(Offset, Ts) ->
+                    <<Offset:64/unsigned,
+                      Ts:64/signed,
+                      1:64/unsigned,
+                      0:32/unsigned,
+                      0:8/unsigned>>
+                end, Offsets, Timestamps),
+    ok = file:write_file(File, [Header | Records]),
+    File.
+
+tmp_idx_file() ->
+    Dir = persistent_term:get({?MODULE, test_dir}),
+    filename:join(Dir, "prop_idx_" ++ integer_to_list(erlang:unique_integer([positive])) ++ ".index").


### PR DESCRIPTION
Currently we use "skip search" to find a requested offset or timestamp in an index file. Skip search sweeps linearly but skips ahead by `?SKIP_SEARCH_JUMP` (2048) elements and then scans linearly within a block where the search knows that the offset/timestamp is in range. We gathered some data in #195 showing how much better skip search is than a regular linear search.

We can improve on lookup times across nearly all index file sizes and target locations with binary search, though. Classic binary search fights with caching (page caching here), so rather we can use a kind of 'two tiered' search which binary searches in blocks of size `?SKIP_SEARCH_JUMP`. Tentatively I'm calling this "block binary search."

I had the :genie: help me make some benchmarking scripts to compare skip search, classic binary search, and block binary search, both with hot page cache and cold. The full results are [in this gist](https://gist.github.com/the-mikedavis/032848704b3a178e8d7d96b971bb4ab6). It's a capture of a run on an `m7g.large` EC2 instance with gp3 EBS at default settings. I see similar behavior on my desktop which has an NVMe.

> Blue: skip_search. Orange: binary_search. Green: block_binary_search.

```mermaid
%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e,#2ca02c'}}}}%%
xychart-beta
    title "Median lookup time vs target position (256k records, hot cache)"
    x-axis ["1%", "5%", "10%", "25%", "50%", "75%", "90%", "95%", "99%"]
    y-axis "Time (μs)" 0 --> 1200
    line [116, 157, 231, 375, 626, 882, 1023, 1079, 1119]
    line [222, 222, 223, 222, 221, 222, 221, 222, 222]
    line [143, 143, 151, 143, 138, 154, 150, 156, 156]
```

```mermaid
%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e,#2ca02c'}}}}%%
xychart-beta
    title "Median lookup time vs index size (target at 50%, hot cache)"
    x-axis ["1k", "10k", "50k", "100k", "256k"]
    y-axis "Time (μs)" 0 --> 650
    line [108, 128, 219, 325, 629]
    line [156, 187, 206, 212, 223]
    line [103, 110, 122, 131, 138]
```

```mermaid
%%{init: {'themeVariables': {'xyChart': {'plotColorPalette': '#1f77b4,#ff7f0e,#2ca02c'}}}}%%
xychart-beta
    title "Median lookup time vs index size (target at 50%, cold cache, EBS gp3)"
    x-axis ["1k", "10k", "50k", "100k", "256k"]
    y-axis "Time (μs)" 0 --> 40000
    line [2008, 4497, 9798, 17097, 38228]
    line [871, 875, 290, 893, 305]
    line [825, 794, 826, 861, 855]
```

> Blue: skip_search. Orange: binary_search. Green: block_binary_search.

Classic binary search has a lot of variance. Block binary search is the most consistent. Skip search only wins when the requested offset/timestamp is in the first 1% of the index file, and it doesn't win by much.