### PR TITLE
Track bloom-filtered record count during chunk iteration

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -59,7 +59,8 @@
          counter_fields/0,
          samples/2,
          make_counter/1,
-         generate_log/4]).
+         generate_log/4,
+         bloom_filtered_count/1]).
 
 -export([dump_init/1,
          dump_init_idx/1,
@@ -417,7 +418,8 @@
       filter_size => 16..255,
       header_data => binary(),
       position => non_neg_integer(),
-      next_position => non_neg_integer()}.
+      next_position => non_neg_integer(),
+      bloom_filtered_count => non_neg_integer()}.
 -type transport() :: tcp | ssl.
 
 %% holds static or rarely changing fields
@@ -451,6 +453,7 @@
          position = 0 :: non_neg_integer(),
          filter :: undefined | osiris_bloom:mstate(),
          filter_size = ?DEFAULT_FILTER_SIZE :: osiris_bloom:filter_size(),
+         bloom_filtered_count = 0 :: non_neg_integer(),
          read_ahead = #ra{} :: #ra{},
          use_sendfile = true :: boolean()}).
 -record(write,
@@ -1461,6 +1464,13 @@ get_default_max_segment_size_bytes() ->
 
 -spec counters_ref(state()) -> counters:counters_ref().
 counters_ref(#?MODULE{cfg = #cfg{counter = C}}) ->
+    C.
+
+%% Returns the number of records in bloom-filtered (skipped) chunks accumulated
+%% since the last yielded chunk. Useful after end_of_stream to account for
+%% records skipped following the final match.
+-spec bloom_filtered_count(state()) -> non_neg_integer().
+bloom_filtered_count(#?MODULE{mode = #read{bloom_filtered_count = C}}) ->
     C.
 
 -spec read_header(state()) ->
@@ -3119,11 +3129,13 @@ parse_header(<<?MAGIC:4/unsigned,
             case osiris_bloom:is_match(ChunkFilter, Filter) of
                 true ->
                     <<HeaderData:?HEADER_SIZE_B/binary, _/binary>> = HeaderData0,
+                    #read{bloom_filtered_count = BloomCount} = Read0,
                     State = case Ra1 of
                                 Ra0 ->
-                                    State0;
+                                    State0#?MODULE{mode = Read0#read{bloom_filtered_count = 0}};
                                 Ra ->
-                                    State0#?MODULE{mode = Read0#read{read_ahead = Ra}}
+                                    State0#?MODULE{mode = Read0#read{read_ahead = Ra,
+                                                                     bloom_filtered_count = 0}}
                             end,
                     {ok, #{chunk_id => NextChId0,
                            epoch => Epoch,
@@ -3137,11 +3149,14 @@ parse_header(<<?MAGIC:4/unsigned,
                            header_data => HeaderData,
                            filter_size => FilterSize,
                            next_position => NextPos,
-                           position => Pos},
+                           position => Pos,
+                           bloom_filtered_count => BloomCount},
                      State};
                 false ->
+                    #read{bloom_filtered_count = BloomCount} = Read0,
                     Read = Read0#read{next_offset = NextChId0 + NumRecords,
                                       position = NextPos,
+                                      bloom_filtered_count = BloomCount + NumRecords,
                                       read_ahead = Ra1},
                     read_header0(State0#?MODULE{mode = Read});
                 {retry_with, NewFilter} ->

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -38,6 +38,7 @@ all_tests() ->
      write_with_filter_attach_next,
      write_batch_with_filter,
      write_batch_with_filters_variable_size,
+     bloom_filtered_count,
      subbatch,
      subbatch_compressed,
      iterator_read_chunk,
@@ -304,6 +305,39 @@ write_batch_with_filters_variable_size(Config) ->
     % int:break(osiris_log, 2908),
     {[{2, <<"hi">>}, _], F2} = osiris_log:read_chunk_parsed(F1),
     osiris_log:close(F2),
+    ok.
+
+bloom_filtered_count(Config) ->
+    Conf0 = ?config(osiris_conf, Config),
+    S0 = osiris_log:init(Conf0#{filter_size => 32}),
+    %% chunk 0: 3 banana records — will not match the apple filter (3 records skipped)
+    {_, S1} = write_committed([{<<"banana">>, <<"a">>},
+                                {<<"banana">>, <<"b">>},
+                                {<<"banana">>, <<"c">>}], S0),
+    %% chunk 1: 1 apple record — will match the apple filter
+    {_, S2} = write_committed([{<<"apple">>, <<"hi">>}], S1),
+    %% chunk 2: 3 banana records — will not match the apple filter (3 records skipped)
+    {_, S3} = write_committed([{<<"banana">>, <<"d">>},
+                                {<<"banana">>, <<"e">>},
+                                {<<"banana">>, <<"f">>}], S2),
+    %% chunk 3: 1 apple record — will match the apple filter
+    {_, S4} = write_committed([{<<"apple">>, <<"hey">>}], S3),
+    %% chunk 4: 3 banana records — will not match (3 records skipped, tail after last match)
+    {_, _S5} = write_committed([{<<"banana">>, <<"g">>},
+                                 {<<"banana">>, <<"h">>},
+                                 {<<"banana">>, <<"i">>}], S4),
+    Shared = osiris_log:get_shared(S0),
+    {ok, R0} = osiris_log:init_offset_reader(
+                   0, add_filter(<<"apple">>, Conf0#{shared => Shared})),
+    %% chunk starting at offset 3 is the first match; chunk 0 (3 records) was skipped
+    {ok, #{chunk_id := 3, bloom_filtered_count := 3}, R1} =
+        osiris_log:read_header(R0),
+    %% chunk starting at offset 7 is the second match; chunk 2 (3 records) was skipped
+    {ok, #{chunk_id := 7, bloom_filtered_count := 3}, R2} =
+        osiris_log:read_header(R1),
+    %% stream ends; chunk 4 (3 records) was skipped after the last match
+    {end_of_stream, R3} = osiris_log:read_header(R2),
+    ?assertEqual(3, osiris_log:bloom_filtered_count(R3)),
     ok.
 
 add_filter(Filter, #{options := Opts} = Conf) ->


### PR DESCRIPTION
When a bloom filter is active on an offset reader, osiris skips entire chunks whose bloom filter does not match the requested filter value. Previously there was no way for callers to know how many records were skipped this way.

This change adds a bloom_filtered_count field to the reader state that accumulates the number of records in bloom-skipped chunks. It is surfaced in two places:
- In the header map returned by chunk_iterator/1,2,3 and read_header/1 for each yielded chunk — the count reflects records skipped in chunks between the previous yielded chunk and the current one. The count resets to zero after each yield
- Via a new bloom_filtered_count/1 accessor on the reader state — useful after {end_of_stream, State} to retrieve records skipped after the final yielded chunk

The count is in records (i.e. NumRecords per skipped chunk), not chunks, so it represents the number of messages that were bypassed without being read.
