### PR TITLE
osiris_log: Handle pread einval in read_header_with_ra/1

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -3101,12 +3101,8 @@ read_header0(State) ->
             {end_of_stream, State}
     end.
 
-read_header_with_ra(#?MODULE{cfg = #cfg{directory = Dir,
-                                        shared = Shared},
-                             mode = #read{next_offset = NextChId0,
-                                          position = Pos,
+read_header_with_ra(#?MODULE{mode = #read{position = Pos,
                                           read_ahead = Ra0} = Read0,
-                             current_file = CurFile,
                              fd = Fd} = State) ->
     case ra_read(Pos, ?HEADER_SIZE_B, Ra0) of
         Bin when is_binary(Bin) andalso
@@ -3118,33 +3114,48 @@ read_header_with_ra(#?MODULE{cfg = #cfg{directory = Dir,
                     ?FUNCTION_NAME(State#?MODULE{mode =
                                                  Read0#read{read_ahead = Ra}});
                 eof ->
-                    FirstOffset = osiris_log_shared:first_chunk_id(Shared),
-                    %% open next segment file and start there if it exists
-                    NextChId = max(FirstOffset, NextChId0),
-                    %% TODO: replace this check with a last chunk id counter
-                    %% updated by the writer and replicas
-                    SegFile = make_file_name(NextChId, "segment"),
-                    case SegFile == CurFile of
-                        true ->
-                            %% the new filename is the same as the old one
-                            %% this should only really happen for an empty
-                            %% log but would cause an infinite loop if it does
-                            {end_of_stream, State};
-                        false ->
-                            case file:open(filename:join(Dir, SegFile),
-                                           [raw, binary, read]) of
-                                {ok, Fd2} ->
-                                    ok = file:close(Fd),
-                                    Read = Read0#read{next_offset = NextChId,
-                                                      read_ahead = ra_clear(Ra0),
-                                                      position = ?LOG_HEADER_SIZE},
-                                    read_header0(State#?MODULE{current_file = SegFile,
-                                                               fd = Fd2,
-                                                               mode = Read});
-                                {error, enoent} ->
-                                    {end_of_stream, State}
-                            end
-                    end
+                    advance_to_next_segment(State);
+                {error, einval} ->
+                    %% pread/3 returns einval if the underlying file has been
+                    %% truncated or removed, or if our Fd has been closed.
+                    %% This can happen when retention concurrently rotates
+                    %% the segment out from under a slow reader. Treat the
+                    %% same as eof and try to advance to the next segment.
+                    advance_to_next_segment(State)
+            end
+    end.
+
+advance_to_next_segment(#?MODULE{cfg = #cfg{directory = Dir,
+                                            shared = Shared},
+                                 mode = #read{next_offset = NextChId0,
+                                              read_ahead = Ra0} = Read0,
+                                 current_file = CurFile,
+                                 fd = Fd} = State) ->
+    FirstOffset = osiris_log_shared:first_chunk_id(Shared),
+    %% open next segment file and start there if it exists
+    NextChId = max(FirstOffset, NextChId0),
+    %% TODO: replace this check with a last chunk id counter
+    %% updated by the writer and replicas
+    SegFile = make_file_name(NextChId, "segment"),
+    case SegFile == CurFile of
+        true ->
+            %% the new filename is the same as the old one
+            %% this should only really happen for an empty
+            %% log but would cause an infinite loop if it does
+            {end_of_stream, State};
+        false ->
+            case file:open(filename:join(Dir, SegFile),
+                           [raw, binary, read]) of
+                {ok, Fd2} ->
+                    ok = file:close(Fd),
+                    Read = Read0#read{next_offset = NextChId,
+                                      read_ahead = ra_clear(Ra0),
+                                      position = ?LOG_HEADER_SIZE},
+                    read_header0(State#?MODULE{current_file = SegFile,
+                                               fd = Fd2,
+                                               mode = Read});
+                {error, enoent} ->
+                    {end_of_stream, State}
             end
     end.
 


### PR DESCRIPTION
## Summary

When `file:pread/3` inside `ra_fill/3` returns `{error, einval}`, the case in `read_header_with_ra/1` only matches `{ok, _}` and `eof`, so the error propagates as a `case_clause` and crashes the reader. This PR adds an `{error, einval}` clause that delegates to the same segment-rotation recovery the `eof` clause already uses.

## Motivation

`file:pread/3` can return `einval` when the underlying file has been truncated or removed, or when the Fd has been closed. With downstream consumers that drive segment retention from outside `osiris` (the rabbitmq tiered-storage plugin, in our case), retention can concurrently rotate the segment out from under a slow reader, producing this error.

We hit this on two consecutive `retention-stress-test` runs in [amazon-mq/rabbitmq-stream-s3#182](https://github.com/amazon-mq/rabbitmq-stream-s3/issues/182): a consumer parked on a 50-second slow remote-tier read, while a writer-side retention hook rotated the local segment underneath it, leading to `case_clause` on the next `pread`. The crash propagates up through `osiris_log:send_file/3`, `rabbit_stream_reader:send_chunks/8`, and ultimately disconnects the consumer.

The crash trace, redacted to the relevant frames:

```
exception error: no case clause matching {'EXIT', {{case_clause, {error, einval}},
  [{osiris_log, read_header_with_ra, 1, [{file, "src/osiris_log.erl"}, {line, 3128}]},
   {osiris_log, send_file, 3, ...},
   ...
```

## Change

Treat `einval` the same as `eof`: try to advance to the next segment, and fall through to `{end_of_stream, State}` if there isn't one. The `eof`-recovery body is extracted into a new `advance_to_next_segment/1` helper so both clauses share it; behavior in the `eof` case is unchanged.

No warning is logged because retention-driven rotation is normal behavior for some consumers and would be noisy; the recovery is automatic. A code comment on the new clause explains why it exists.

The other two `ra_fill/3` callsites (in `parse_header/2` and `iter_read_ahead/7`) are intentionally left as `{ok, _} = ra_fill(...)` hard matches. Both are reached only after the chunk header has already been read successfully, so an `einval` there would be a deeper inconsistency that should not be silently swallowed.

## Test plan

- [x] `make` compiles cleanly
- [x] `make ct-osiris_log` passes 93/93
- [x] `make ct-osiris_log_prop` passes 2/2 (500 prop runs each)
- [x] `make ct-osiris` passes 60/60
