### PR TITLE
Fix first_timestamp counter not set on first chunk write

### DIFF
--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -2628,7 +2628,7 @@ write_chunk(Chunk,
             %% update counters
             counters:put(CntRef, ?C_OFFSET, NextOffset - 1),
             counters:add(CntRef, ?C_CHUNKS, 1),
-            maybe_set_first_offset(Next, Cfg),
+            maybe_set_first_offset(Next, Timestamp, Cfg),
             State#?MODULE{mode =
                           Write#write{tail_info = {NextOffset,
                                                    {Epoch, Next, Timestamp}},
@@ -2637,9 +2637,11 @@ write_chunk(Chunk,
     end.
 
 
-maybe_set_first_offset(0, #cfg{shared = Ref}) ->
+maybe_set_first_offset(0, Timestamp, #cfg{shared = Ref, counter = CntRef}) ->
+    counters:put(CntRef, ?C_FIRST_OFFSET, 0),
+    counters:put(CntRef, ?C_FIRST_TIMESTAMP, Timestamp),
     osiris_log_shared:set_first_chunk_id(Ref, 0);
-maybe_set_first_offset(_, _Cfg) ->
+maybe_set_first_offset(_, _Timestamp, _Cfg) ->
     ok.
 
 max_segment_size_reached(

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -35,6 +35,7 @@ all_tests() ->
      init_recover_with_writers,
      init_with_lower_epoch,
      write_batch,
+     write_first_chunk_updates_first_timestamp,
      write_with_filter_attach_next,
      write_batch_with_filter,
      write_batch_with_filters_variable_size,
@@ -229,6 +230,15 @@ write_batch(Config) ->
     ?assertEqual(0, osiris_log:next_offset(S0)),
     S1 = osiris_log:write([<<"hi">>], S0),
     ?assertEqual(1, osiris_log:next_offset(S1)),
+    ok.
+
+write_first_chunk_updates_first_timestamp(Config) ->
+    Conf = ?config(osiris_conf, Config),
+    S0 = osiris_log:init(Conf),
+    ?assertEqual(0, osiris_log:first_timestamp(S0)),
+    Ts = 424242,
+    S1 = osiris_log:write([<<"hi">>], ?CHNK_USER, Ts, <<>>, S0),
+    ?assertEqual(Ts, osiris_log:first_timestamp(S1)),
     ok.
 
 write_with_filter_attach_next(Config) ->


### PR DESCRIPTION
first_timestamp/1 returned 0 for a freshly created log until process restart or a retention-triggered segment rollover, since write_chunk/6 never updated the C_FIRST_TIMESTAMP counter for the log's first chunk.