### PR TITLE
Soften ok = setopts nopush matches in osiris_replica_reader

### DIFF
--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -329,7 +329,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 do_sendfile(#state{socket = Sock,
                    transport = Transport} = State) ->
-    ok = setopts(Transport, Sock, [{nopush, true}]),
+    _ = setopts(Transport, Sock, [{nopush, true}]),
     do_sendfile0(State).
 
 do_sendfile0(#state{name = Name,
@@ -347,7 +347,7 @@ do_sendfile0(#state{name = Name,
             ?DEBUG_(Name, "sendfile err ~w", [_Err]),
             State;
         {end_of_stream, Log} ->
-            ok = setopts(Transport, Sock, [{nopush, false}]),
+            _ = setopts(Transport, Sock, [{nopush, false}]),
             State#state{log = Log}
     end.
 


### PR DESCRIPTION
Setting TCP_NOPUSH can fail with EINVAL on an already-broken replica->writer socket (e.g. writer node restarting under load, observed on macOS). The hard ok = match crash-looped the replica reader, keeping streams below quorum+1 and hanging await_online_quorum_plus_one during rolling restarts. nopush is only a latency hint, so ignore setopts failures here as the error branch already does, and let the reader tear down/reconnect normally.