### PR TITLE
Smaller crash fixes

### DIFF
--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -102,7 +102,7 @@ start(Node, Config = #{name := Name}) when ?IS_STRING(Name) ->
                                 #{id => Name,
                                   start => {?MODULE, start_link, [Config]},
                                   restart => temporary,
-                                  shutdown => 5000,
+                                  shutdown => 1000,
                                   type => worker,
                                   modules => [?MODULE]}) of
         {ok, Pid} = Res ->
@@ -513,7 +513,7 @@ handle_info({socket, Socket}, #?MODULE{cfg = #cfg{name = Name,
     case recv(Transport, Socket, ?TOKEN_SIZE, Timeout) of
         {ok, Token} ->
             %% token validated, all good we can let the flood of data begin
-            ok = setopts(Transport, Socket, [{active, 5}]),
+            ok = setopts(Transport, Socket, [{active, 2}]),
             {noreply, State#?MODULE{cfg = Cfg#cfg{socket = Socket}}};
         {ok, Other} ->
             ?WARN_(Name, "invalid token received ~w expected ~w",

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -81,7 +81,7 @@ start(Node, ReplicaReaderConf) when is_map(ReplicaReaderConf) ->
                                  %% instead they need to be re-started
                                  %% by their replica
                                  restart => temporary,
-                                 shutdown => 5000,
+                                 shutdown => 100,
                                  type => worker,
                                  modules => [osiris_replica_reader]})
     catch

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -366,8 +366,7 @@ maybe_send_committed_chunk_id(#state{log = Log,
                           COffs
                   end,
 
-            ok = erlang:send(RPid, {'$gen_cast', {committed_offset, Msg}},
-                             [noconnect, nosuspend]),
+            _ = erlang:send(RPid, {'$gen_cast', {committed_offset, Msg}}),
             State#state{committed_offset = COffs};
         _ ->
             State


### PR DESCRIPTION
- Fix a crash risk: erlang:send/3 with [noconnect, nosuspend] can return noconnect/nosuspend instead of ok, which the old ok = ... match on the committed_offset cast would crash on. Now a plain best-effort send.
- Shorten replica/replica-reader shutdown timeouts (5000ms → 1000ms/100ms) and lower the post-handshake socket {active, N} from 5 to 2, so a node with many streams shuts each one down faster.