### PR TITLE
Add log-reader abstractions and hooks into writer/replica lifecycles

### DIFF
--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -68,8 +68,12 @@
     {abs, offset()} |
     offset() |
     {timestamp, timestamp()}.
+-type retention_fun() :: fun((IdxFiles :: [file:filename_all()]) ->
+    {ToDelete :: [file:filename_all()], ToKeep :: [file:filename_all()]}).
 -type retention_spec() ::
-    {max_bytes, non_neg_integer()} | {max_age, milliseconds()}.
+    {max_bytes, non_neg_integer()} |
+    {max_age, milliseconds()} |
+    {'fun', retention_fun()}.
 -type writer_id() :: binary().
 -type batch() :: {batch, NumRecords :: non_neg_integer(),
                   compression_type(),
@@ -92,6 +96,7 @@
               tracking_id/0,
               offset_spec/0,
               retention_spec/0,
+              retention_fun/0,
               timestamp/0,
               writer_id/0,
               data/0,

--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -74,6 +74,9 @@
     {max_bytes, non_neg_integer()} |
     {max_age, milliseconds()} |
     {'fun', retention_fun()}.
+-type retention_update() ::
+    [retention_spec()] |
+    fun(([retention_spec()]) -> [retention_spec()]).
 -type writer_id() :: binary().
 -type batch() :: {batch, NumRecords :: non_neg_integer(),
                   compression_type(),
@@ -96,6 +99,7 @@
               tracking_id/0,
               offset_spec/0,
               retention_spec/0,
+              retention_update/0,
               retention_fun/0,
               timestamp/0,
               writer_id/0,
@@ -275,10 +279,10 @@ register_offset_listener(Pid, Offset, EvtFormatter) ->
     end,
     ok.
 
--spec update_retention(pid(), [osiris:retention_spec()]) ->
+-spec update_retention(pid(), retention_update()) ->
     ok | {error, term()}.
 update_retention(Pid, Retention)
-    when is_pid(Pid) andalso is_list(Retention) ->
+    when is_pid(Pid) andalso (is_list(Retention) orelse is_function(Retention, 1)) ->
     Msg = {update_retention, Retention},
     try
         case gen:call(Pid, '$gen_call', Msg) of

--- a/src/osiris.erl
+++ b/src/osiris.erl
@@ -83,11 +83,6 @@
 
 %% returned when reading
 -type entry() :: binary() | batch().
--type reader_options() :: #{transport => tcp | ssl,
-                            chunk_selector => all | user_data,
-                            filter_spec => osiris_bloom:filter_spec(),
-                            read_ahead => boolean() | non_neg_integer()
-                           }.
 
 -export_type([name/0,
               config/0,
@@ -228,8 +223,9 @@ init_reader(Pid, OffsetSpec, CounterSpec) ->
                                                 chunk_selector => user_data}).
 
 -spec init_reader(pid(), offset_spec(), osiris_log:counter_spec(),
-                  reader_options()) ->
-    {ok, osiris_log:state()} |
+                  osiris_log_reader:options()) ->
+    {ok, osiris_log_reader:state()} |
+    {error, osiris_log_reader:transient_error()} |
     {error, {offset_out_of_range, empty | {offset(), offset()}}} |
     {error, {invalid_last_offset_epoch, offset(), offset()}}.
 init_reader(Pid, OffsetSpec, {_, _} = CounterSpec, Options)
@@ -238,10 +234,11 @@ init_reader(Pid, OffsetSpec, {_, _} = CounterSpec, Options)
     Ctx0 = osiris_util:get_reader_context(Pid),
     Ctx = Ctx0#{counter_spec => CounterSpec,
                 options => Options},
-    osiris_log:init_offset_reader(OffsetSpec, Ctx).
+    (osiris_log_reader:module()):init_offset_reader(OffsetSpec, Ctx).
 
--spec resolve_offset_spec(pid(), offset_spec(), reader_options()) ->
+-spec resolve_offset_spec(pid(), offset_spec(), osiris_log_reader:options()) ->
     {ok, offset()} |
+    {error, osiris_log_reader:transient_error()} |
     {error, no_index_file} |
     {error, {offset_out_of_range, osiris_log:range()}} |
     {error, retries_exhausted}.
@@ -249,7 +246,7 @@ resolve_offset_spec(Pid, OffsetSpec, Options)
     when is_pid(Pid) andalso node(Pid) =:= node() ->
     Ctx0 = osiris_util:get_reader_context(Pid),
     Ctx = Ctx0#{options => Options},
-    osiris_log:resolve_offset_spec(OffsetSpec, Ctx).
+    (osiris_log_reader:module()):resolve_offset_spec(OffsetSpec, Ctx).
 
 -spec register_offset_listener(pid(), offset()) -> ok.
 register_offset_listener(Pid, Offset) ->

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -2696,6 +2696,14 @@ app_env_log_hooks() ->
         undefined -> undefined
     end.
 
+run_retention_evaluated_hook(undefined, _Cnt, _Ctx) ->
+    ok;
+run_retention_evaluated_hook(HookMod, Cnt, Ctx) ->
+    case erlang:function_exported(HookMod, on_retention_evaluated, 2) of
+        true -> HookMod:on_retention_evaluated(Cnt, Ctx);
+        false -> ok
+    end.
+
 max_segment_size_reached(
   #?MODULE{mode = #write{segment_size = {CurrentSizeBytes,
                                          CurrentSizeChunks}},
@@ -3299,13 +3307,16 @@ trigger_retention_eval(#?MODULE{cfg =
 
     %% updates first offset and first timestamp
     %% after retention has been evaluated
+    HookMod = app_env_log_hooks(),
     EvalFun = fun ({{FstOff, _}, FstTs, NumSegLeft})
                     when is_integer(FstOff),
                          is_integer(FstTs) ->
                       osiris_log_shared:set_first_chunk_id(Shared, FstOff),
                       counters:put(Cnt, ?C_FIRST_OFFSET, FstOff),
                       counters:put(Cnt, ?C_FIRST_TIMESTAMP, FstTs),
-                      counters:put(Cnt, ?C_SEGMENTS, NumSegLeft);
+                      counters:put(Cnt, ?C_SEGMENTS, NumSegLeft),
+                      run_retention_evaluated_hook(HookMod, Cnt,
+                                                   #{name => Name});
                   (_) ->
                       ok
               end,

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -2293,14 +2293,15 @@ evaluate_retention(Dir, Specs) when is_binary(Dir) ->
     ?DEBUG_(<<>>," (~w) completed in ~fms", [Specs, Time/1_000]),
     Result.
 
-evaluate_retention0(IdxFiles, []) ->
-    IdxFiles;
-evaluate_retention0(IdxFiles, [{max_bytes, MaxSize} | Specs]) ->
-    RemIdxFiles = eval_max_bytes(IdxFiles, MaxSize),
-    evaluate_retention0(RemIdxFiles, Specs);
-evaluate_retention0(IdxFiles, [{max_age, Age} | Specs]) ->
-    RemIdxFiles = eval_age(IdxFiles, Age),
-    evaluate_retention0(RemIdxFiles, Specs).
+evaluate_retention0(IdxFiles, Specs) ->
+    lists:foldl(
+      fun ({max_bytes, MaxSize}, RemIdxFiles) ->
+              eval_max_bytes(RemIdxFiles, MaxSize);
+          ({max_age, Age}, RemIdxFiles) ->
+              eval_age(RemIdxFiles, Age);
+          ({'fun', Fun}, RemIdxFiles) ->
+              eval_retention_fun(RemIdxFiles, Fun)
+      end, IdxFiles, Specs).
 
 eval_age([_] = IdxFiles, _Age) ->
     IdxFiles;
@@ -2364,6 +2365,13 @@ file_size_or_zero(Path) ->
         {error, enoent} ->
             0
     end.
+
+eval_retention_fun([], _) ->
+    [];
+eval_retention_fun(IdxFiles, Fun) ->
+    {ToDelete, ToKeep} = Fun(IdxFiles),
+    _ = [ok = delete_segment_from_index(Idx) || Idx <- ToDelete],
+    ToKeep.
 
 last_epoch_chunk_ids(Name, IdxFiles) ->
     T1 = erlang:monotonic_time(),

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -60,7 +60,8 @@
          counter_fields/0,
          samples/2,
          make_counter/1,
-         generate_log/4]).
+         generate_log/4,
+         parse_header/2]).
 
 -export([dump_init/1,
          dump_init_idx/1,
@@ -410,19 +411,19 @@
 -type offset_spec() :: osiris:offset_spec().
 -type retention_spec() :: osiris:retention_spec().
 -type header_map() ::
-    #{chunk_id => offset(),
-      epoch => epoch(),
-      type => chunk_type(),
-      crc => integer(),
-      num_records => non_neg_integer(),
-      num_entries => non_neg_integer(),
-      timestamp => osiris:timestamp(),
-      data_size => non_neg_integer(),
-      trailer_size => non_neg_integer(),
-      filter_size => 16..255,
-      header_data => binary(),
-      position => non_neg_integer(),
-      next_position => non_neg_integer()}.
+    #{chunk_id := offset(),
+      epoch := epoch(),
+      type := chunk_type(),
+      crc := integer(),
+      num_records := non_neg_integer(),
+      num_entries := non_neg_integer(),
+      timestamp := osiris:timestamp(),
+      data_size := non_neg_integer(),
+      trailer_size := non_neg_integer(),
+      filter_size := 16..255,
+      header_data := binary(),
+      position := non_neg_integer(),
+      next_position := non_neg_integer()}.
 -type transport() :: tcp | ssl.
 
 %% holds static or rarely changing fields
@@ -3160,7 +3161,8 @@ read_header_with_ra(#?MODULE{cfg = #cfg{shared = Shared},
     case ra_read(Pos, ?HEADER_SIZE_B, Ra0) of
         Bin when is_binary(Bin) andalso
                  byte_size(Bin) == ?HEADER_SIZE_B ->
-            parse_header(Bin, State);
+            {ok, Header} = parse_header(Bin, Pos),
+            read_header_with_ra0(Header, State);
         undefined ->
             case ra_fill(Fd, Pos, Ra0) of
                 {ok, Ra} ->
@@ -3176,60 +3178,36 @@ read_header_with_ra(#?MODULE{cfg = #cfg{shared = Shared},
             end
     end.
 
-parse_header(<<?MAGIC:4/unsigned,
-               ?VERSION:4/unsigned,
-               ChType:8/unsigned,
-               NumEntries:16/unsigned,
-               NumRecords:32/unsigned,
-               Timestamp:64/signed,
-               Epoch:64/unsigned,
-               NextChId0:64/unsigned,
-               Crc:32/integer,
-               DataSize:32/unsigned,
-               TrailerSize:32/unsigned,
-               FilterSize:8/unsigned,
-               _Reserved:24>> = HeaderData0,
-             #?MODULE{cfg = #cfg{counter = CntRef},
-                      fd = Fd,
-                      mode = #read{next_offset = NextChId0,
-                                   position = Pos,
-                                   filter = Filter,
-                                   read_ahead = Ra0} = Read0} = State0) ->
-
+read_header_with_ra0(#{chunk_id := NextChId0,
+                       num_records := NumRecords,
+                       data_size := DataSize,
+                       filter_size := FilterSize,
+                       next_position := NextPos} = Header,
+                     #?MODULE{cfg = #cfg{counter = CntRef},
+                              fd = Fd,
+                              mode = #read{next_offset = NextChId0,
+                                           position = Pos,
+                                           filter = Filter,
+                                           read_ahead = Ra0} = Read0} = State0) ->
     Ra1 = ra_update_size(Filter, FilterSize, DataSize, Ra0),
     case ra_read(Pos + ?HEADER_SIZE_B, FilterSize, Ra1) of
         undefined ->
             {ok, Ra} = ra_fill(Fd, Pos + ?HEADER_SIZE_B, Ra1),
-            parse_header(HeaderData0,
-                         State0#?MODULE{mode = Read0#read{read_ahead = Ra}});
+            State = State0#?MODULE{mode = Read0#read{read_ahead = Ra}},
+            read_header_with_ra0(Header, State);
         ChunkFilter ->
             counters:put(CntRef, ?C_OFFSET, NextChId0 + NumRecords),
             counters:add(CntRef, ?C_CHUNKS, 1),
-            NextPos = Pos + ?HEADER_SIZE_B + FilterSize + DataSize + TrailerSize,
 
             case osiris_bloom:is_match(ChunkFilter, Filter) of
                 true ->
-                    <<HeaderData:?HEADER_SIZE_B/binary, _/binary>> = HeaderData0,
                     State = case Ra1 of
                                 Ra0 ->
                                     State0;
                                 Ra ->
                                     State0#?MODULE{mode = Read0#read{read_ahead = Ra}}
                             end,
-                    {ok, #{chunk_id => NextChId0,
-                           epoch => Epoch,
-                           type => ChType,
-                           crc => Crc,
-                           num_records => NumRecords,
-                           num_entries => NumEntries,
-                           timestamp => Timestamp,
-                           data_size => DataSize,
-                           trailer_size => TrailerSize,
-                           header_data => HeaderData,
-                           filter_size => FilterSize,
-                           next_position => NextPos,
-                           position => Pos},
-                     State};
+                    {ok, Header, State};
                 false ->
                     Read = Read0#read{next_offset = NextChId0 + NumRecords,
                                       position = NextPos,
@@ -3245,6 +3223,40 @@ parse_header(<<?MAGIC:4/unsigned,
                     read_header0(State0#?MODULE{mode = Read})
             end
     end.
+
+-spec parse_header(binary(), Pos :: pos_integer()) ->
+    {ok, header_map()} |
+    {error, invalid_chunk_header}.
+parse_header(<<?MAGIC:4/unsigned,
+               ?VERSION:4/unsigned,
+               ChType:8/unsigned,
+               NumEntries:16/unsigned,
+               NumRecords:32/unsigned,
+               Timestamp:64/signed,
+               Epoch:64/unsigned,
+               NextChId0:64/unsigned,
+               Crc:32/integer,
+               DataSize:32/unsigned,
+               TrailerSize:32/unsigned,
+               FilterSize:8/unsigned,
+               _Reserved:24>> = HeaderData,
+             Pos) ->
+    NextPos = Pos + ?HEADER_SIZE_B + FilterSize + DataSize + TrailerSize,
+    {ok, #{chunk_id => NextChId0,
+           epoch => Epoch,
+           type => ChType,
+           crc => Crc,
+           num_records => NumRecords,
+           num_entries => NumEntries,
+           timestamp => Timestamp,
+           data_size => DataSize,
+           trailer_size => TrailerSize,
+           header_data => HeaderData,
+           filter_size => FilterSize,
+           next_position => NextPos,
+           position => Pos}};
+parse_header(_, _) ->
+    {error, invalid_chunk_header}.
 
 %% keep the previous value if the current one is 0 (i.e. no filter in the chunk)
 read_ahead_fsize(Previous, 0) ->

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -518,20 +518,11 @@ init(Config) ->
 -spec init(config(), writer | acceptor) -> state().
 init(#{dir := Dir,
        name := Name,
-       epoch := Epoch} = Config,
+       epoch := Epoch} = Config0,
      WriterType) ->
     %% scan directory for segments if in write mode
-    MaxSizeBytes = maps:get(max_segment_size_bytes, Config,
-                            ?DEFAULT_MAX_SEGMENT_SIZE_B),
-    MaxSizeChunks = application:get_env(osiris, max_segment_size_chunks,
-                                        ?DEFAULT_MAX_SEGMENT_SIZE_C),
-    Retention = maps:get(retention, Config, []),
-    FilterSize = maps:get(filter_size, Config, ?DEFAULT_FILTER_SIZE),
     ?INFO("Stream: ~ts will use ~ts for osiris log data directory",
           [Name, Dir]),
-    ?DEBUG_(Name, "max_segment_size_bytes: ~b,
-           max_segment_size_chunks ~b, retention ~w, filter size ~b",
-            [MaxSizeBytes, MaxSizeChunks, Retention, FilterSize]),
     ok = filelib:ensure_dir(Dir),
     case file:make_dir(Dir) of
         ok ->
@@ -541,19 +532,36 @@ init(#{dir := Dir,
         Err ->
             throw(Err)
     end,
+    ok = maybe_fix_corrupted_files(Config0),
+    MaxSizeBytes = maps:get(max_segment_size_bytes, Config0,
+                            ?DEFAULT_MAX_SEGMENT_SIZE_B),
+    MaxSizeChunks = application:get_env(osiris, max_segment_size_chunks,
+                                        ?DEFAULT_MAX_SEGMENT_SIZE_C),
+    FilterSize = maps:get(filter_size, Config0, ?DEFAULT_FILTER_SIZE),
+    ?DEBUG_(Name, "max_segment_size_bytes: ~b,
+           max_segment_size_chunks ~b, retention ~w, filter size ~b",
+            [MaxSizeBytes, MaxSizeChunks,
+             maps:get(retention, Config0, []), FilterSize]),
 
-    Cnt = make_counter(Config),
+    Cnt = make_counter(Config0),
     %% initialise offset counter to -1 as 0 is the first offset in the log and
     %% it hasn't necessarily been written yet, for an empty log the first offset
     %% is initialised to 0 however and will be updated after each retention run.
     counters:put(Cnt, ?C_OFFSET, -1),
     counters:put(Cnt, ?C_SEGMENTS, 0),
-    Shared = case Config of
+    Shared = case Config0 of
                  #{shared := S} ->
                      S;
                  _ ->
                      osiris_log_shared:new()
              end,
+    Config = case maps:get(log_hooks, Config0, app_env_log_hooks()) of
+                 undefined ->
+                     Config0;
+                 HookMod ->
+                     HookMod:on_init(WriterType, self(), Config0#{counter => Cnt, shared => Shared})
+             end,
+    Retention = maps:get(retention, Config, []),
     Cfg = #cfg{directory = Dir,
                name = Name,
                max_segment_size_bytes = MaxSizeBytes,
@@ -564,7 +572,6 @@ init(#{dir := Dir,
                counter_id = counter_id(Config),
                shared = Shared,
                filter_size = FilterSize},
-    ok = maybe_fix_corrupted_files(Config),
     DefaultNextOffset = case Config of
                             #{initial_offset := IO}
                               when WriterType == acceptor ->
@@ -2266,11 +2273,24 @@ format_status(#?MODULE{cfg = #cfg{directory = Dir,
       file => filename:basename(File)}.
 
 -spec update_retention([retention_spec()], state()) -> state().
-update_retention(Retention,
+update_retention(Retention0,
                  #?MODULE{cfg = #cfg{name = Name,
-                                     retention = Retention0} = Cfg} = State0)
-    when is_list(Retention) ->
-    ?DEBUG_(Name, " from: ~w to ~w", [Retention0, Retention]),
+                                     directory = Dir,
+                                     counter = Cnt,
+                                     shared = Shared,
+                                     retention = RetentionPrev} = Cfg} = State0)
+    when is_list(Retention0) ->
+    Retention = case application:get_env(osiris, log_hooks) of
+                    {ok, HookMod} ->
+                        HookMod:on_retention_updated(Retention0,
+                                                     #{name => Name,
+                                                       dir => Dir,
+                                                       counter => Cnt,
+                                                       shared => Shared});
+                    undefined ->
+                        Retention0
+                end,
+    ?DEBUG_(Name, " from: ~w to ~w", [RetentionPrev, Retention]),
     State = State0#?MODULE{cfg = Cfg#cfg{retention = Retention}},
     trigger_retention_eval(State).
 
@@ -2669,6 +2689,12 @@ maybe_set_first_offset(0, Timestamp, #cfg{shared = Ref, counter = CntRef}) ->
     osiris_log_shared:set_first_chunk_id(Ref, 0);
 maybe_set_first_offset(_, _Timestamp, _Cfg) ->
     ok.
+
+app_env_log_hooks() ->
+    case application:get_env(osiris, log_hooks) of
+        {ok, Mod} -> Mod;
+        undefined -> undefined
+    end.
 
 max_segment_size_reached(
   #?MODULE{mode = #write{segment_size = {CurrentSizeBytes,

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -2272,23 +2272,29 @@ format_status(#?MODULE{cfg = #cfg{directory = Dir,
       filter_size => FilterSize,
       file => filename:basename(File)}.
 
--spec update_retention([retention_spec()], state()) -> state().
-update_retention(Retention0,
+-spec update_retention(osiris:retention_update(), state()) -> state().
+update_retention(RetentionOrFun,
                  #?MODULE{cfg = #cfg{name = Name,
                                      directory = Dir,
                                      counter = Cnt,
                                      shared = Shared,
                                      retention = RetentionPrev} = Cfg} = State0)
-    when is_list(Retention0) ->
+    when is_list(RetentionOrFun) orelse is_function(RetentionOrFun, 1) ->
+    Retention1 = case RetentionOrFun of
+                     Fun when is_function(Fun, 1) ->
+                         Fun(RetentionPrev);
+                     List ->
+                         List
+                 end,
     Retention = case application:get_env(osiris, log_hooks) of
                     {ok, HookMod} ->
-                        HookMod:on_retention_updated(Retention0,
+                        HookMod:on_retention_updated(Retention1,
                                                      #{name => Name,
                                                        dir => Dir,
                                                        counter => Cnt,
                                                        shared => Shared});
                     undefined ->
-                        Retention0
+                        Retention1
                 end,
     ?DEBUG_(Name, " from: ~w to ~w", [RetentionPrev, Retention]),
     State = State0#?MODULE{cfg = Cfg#cfg{retention = Retention}},

--- a/src/osiris_log.erl
+++ b/src/osiris_log.erl
@@ -28,6 +28,7 @@
          send_file/3,
          init_data_reader/2,
          init_offset_reader/2,
+         open_next_segment/1,
          resolve_offset_spec/2,
          read_header/1,
          chunk_iterator/1,
@@ -496,7 +497,8 @@
               range/0,
               config/0,
               counter_spec/0,
-              transport/0]).
+              transport/0,
+              header_map/0]).
 
 -spec directory(osiris:config() | list()) -> file:filename_all().
 directory(#{name := Name, dir := Dir}) ->
@@ -1487,6 +1489,13 @@ read_header(#?MODULE{cfg = #cfg{}} = State0) ->
                                             position = NextPos}}};
         {end_of_stream, _} = EOF ->
             EOF;
+        {offset_not_found, State1} ->
+            case open_next_segment(State1) of
+                {ok, State} ->
+                    read_header(State);
+                not_found ->
+                    {end_of_stream, State1}
+            end;
         {error, _} = Err ->
             Err
     end.
@@ -1518,6 +1527,7 @@ read_header(#?MODULE{cfg = #cfg{}} = State0) ->
 -spec chunk_iterator(state()) ->
     {ok, header_map(), chunk_iterator(), state()} |
     {end_of_stream, state()} |
+    {offset_not_found, state()} |
     {error, {invalid_chunk_header, term()}}.
 chunk_iterator(State) ->
     chunk_iterator(State, 1).
@@ -1525,6 +1535,7 @@ chunk_iterator(State) ->
 -spec chunk_iterator(state(), pos_integer() | all) ->
     {ok, header_map(), chunk_iterator(), state()} |
     {end_of_stream, state()} |
+    {offset_not_found, state()} |
     {error, {invalid_chunk_header, term()}}.
 chunk_iterator(State, Credit) ->
     chunk_iterator(State, Credit, undefined).
@@ -1534,6 +1545,7 @@ chunk_iterator(State, Credit) ->
                      chunk_iterator() | undefined) ->
     {ok, header_map(), chunk_iterator(), state()} |
     {end_of_stream, state()} |
+    {offset_not_found, state()} |
     {error, {invalid_chunk_header, term()}}.
 chunk_iterator(#?MODULE{cfg = #cfg{},
                         mode = #read{type = RType,
@@ -1718,6 +1730,9 @@ read_chunk_parsed(#?MODULE{mode = #read{}} = State0,
     case chunk_iterator(State0, all) of
         {end_of_stream, _} = Eos ->
             Eos;
+        {offset_not_found, State1} ->
+            {ok, State} = open_next_segment(State1),
+            read_chunk_parsed(State, HeaderOrNot);
         {ok, _H, I0, State1} when HeaderOrNot == no_header ->
             Records = iter_all_records(iterator_next(I0), []),
             {Records, State1};
@@ -1782,6 +1797,7 @@ is_valid_chunk_on_disk(SegFile, Pos) ->
 -spec send_file(gen_tcp:socket(), state()) ->
                    {ok, state()} |
                    {error, term()} |
+                   {offset_not_found, state()} |
                    {end_of_stream, state()}.
 send_file(Sock, State) ->
     send_file(Sock, State, fun(_, _) -> <<>> end).
@@ -1790,6 +1806,7 @@ send_file(Sock, State) ->
                 fun((header_map(), non_neg_integer()) -> binary())) ->
     {ok, state()} |
     {error, term()} |
+    {offset_not_found, state()} |
     {end_of_stream, state()}.
 send_file(Sock,
           #?MODULE{mode = #read{type = RType,
@@ -3091,8 +3108,32 @@ recover_tracking(Fd, Trk0, Pos0) ->
             Trk0
     end.
 
+-spec open_next_segment(state()) -> {ok, state()} | not_found.
+open_next_segment(#?MODULE{cfg = #cfg{shared = Shared,
+                                      directory = Dir},
+                           mode = #read{read_ahead = Ra0,
+                                        next_offset = NextChId0} = Read0,
+                           fd = Fd} = State0) ->
+    FirstChId = osiris_log_shared:first_chunk_id(Shared),
+    NextChId = max(FirstChId, NextChId0),
+    SegFile = make_file_name(NextChId, "segment"),
+    case file:open(filename:join(Dir, SegFile), [raw, binary, read]) of
+        {ok, Fd2} ->
+            ok = file:close(Fd),
+            Read = Read0#read{next_offset = NextChId,
+                              read_ahead = ra_clear(Ra0),
+                              position = ?LOG_HEADER_SIZE},
+            State = State0#?MODULE{current_file = SegFile,
+                                   fd = Fd2,
+                                   mode = Read},
+            {ok, State};
+        {error, enoent} ->
+            not_found
+    end.
+
 -spec read_header0(state()) ->
     {ok, map(), state()} |
+    {offset_not_found, state()} |
     {end_of_stream, state()}.
 read_header0(State) ->
     %% reads the next header if permitted
@@ -3103,12 +3144,10 @@ read_header0(State) ->
             {end_of_stream, State}
     end.
 
-read_header_with_ra(#?MODULE{cfg = #cfg{directory = Dir,
-                                        shared = Shared},
+read_header_with_ra(#?MODULE{cfg = #cfg{shared = Shared},
                              mode = #read{next_offset = NextChId0,
                                           position = Pos,
                                           read_ahead = Ra0} = Read0,
-                             current_file = CurFile,
                              fd = Fd} = State) ->
     case ra_read(Pos, ?HEADER_SIZE_B, Ra0) of
         Bin when is_binary(Bin) andalso
@@ -3120,32 +3159,11 @@ read_header_with_ra(#?MODULE{cfg = #cfg{directory = Dir,
                     ?FUNCTION_NAME(State#?MODULE{mode =
                                                  Read0#read{read_ahead = Ra}});
                 eof ->
-                    FirstOffset = osiris_log_shared:first_chunk_id(Shared),
-                    %% open next segment file and start there if it exists
-                    NextChId = max(FirstOffset, NextChId0),
-                    %% TODO: replace this check with a last chunk id counter
-                    %% updated by the writer and replicas
-                    SegFile = make_file_name(NextChId, "segment"),
-                    case SegFile == CurFile of
+                    case NextChId0 > osiris_log_shared:last_chunk_id(Shared) of
                         true ->
-                            %% the new filename is the same as the old one
-                            %% this should only really happen for an empty
-                            %% log but would cause an infinite loop if it does
                             {end_of_stream, State};
                         false ->
-                            case file:open(filename:join(Dir, SegFile),
-                                           [raw, binary, read]) of
-                                {ok, Fd2} ->
-                                    ok = file:close(Fd),
-                                    Read = Read0#read{next_offset = NextChId,
-                                                      read_ahead = ra_clear(Ra0),
-                                                      position = ?LOG_HEADER_SIZE},
-                                    read_header0(State#?MODULE{current_file = SegFile,
-                                                               fd = Fd2,
-                                                               mode = Read});
-                                {error, enoent} ->
-                                    {end_of_stream, State}
-                            end
+                            {offset_not_found, State}
                     end
             end
     end.

--- a/src/osiris_log_hooks.erl
+++ b/src/osiris_log_hooks.erl
@@ -18,3 +18,8 @@
 
 -callback on_retention_updated([osiris:retention_spec()], map()) ->
     [osiris:retention_spec()].
+
+-callback on_retention_evaluated(counters:counters_ref(), map()) ->
+    ok.
+
+-optional_callbacks([on_retention_evaluated/2]).

--- a/src/osiris_log_hooks.erl
+++ b/src/osiris_log_hooks.erl
@@ -1,0 +1,20 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2026 Broadcom. All Rights Reserved. The term Broadcom refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(osiris_log_hooks).
+
+%% Behaviour for hooking into log lifecycle events.
+%%
+%% Discovered via `application:get_env(osiris, log_hooks, undefined)`. When
+%% `undefined`, no hooks fire. A plugin sets the env on boot to receive
+%% callbacks at lifecycle boundaries.
+
+-callback on_init(writer | acceptor, pid(), osiris_log:config()) ->
+    osiris_log:config().
+
+-callback on_retention_updated([osiris:retention_spec()], map()) ->
+    [osiris:retention_spec()].

--- a/src/osiris_log_reader.erl
+++ b/src/osiris_log_reader.erl
@@ -1,0 +1,124 @@
+%% This Source Code Form is subject to the terms of the Mozilla Public
+%% License, v. 2.0. If a copy of the MPL was not distributed with this
+%% file, You can obtain one at https://mozilla.org/MPL/2.0/.
+%%
+%% Copyright (c) 2007-2025 Broadcom. All Rights Reserved. The term Broadcom refers to Broadcom Inc. and/or its subsidiaries.
+%%
+
+-module(osiris_log_reader).
+
+-export([next_offset/1,
+         committed_offset/1,
+         committed_chunk_id/1,
+         close/1,
+         send_file/2,
+         send_file/3,
+         chunk_iterator/2,
+         chunk_iterator/3,
+         iterator_next/1]).
+
+%% Exported for internal usage
+-export([module/0]).
+
+-type options() :: #{transport => tcp | ssl,
+                     chunk_selector => all | user_data,
+                     filter_spec => osiris_bloom:filter_spec(),
+                     read_ahead => boolean() | non_neg_integer()
+                    }.
+-type config() ::
+    osiris:config() |
+    #{counter_spec := osiris_log:counter_spec(),
+      options := options()}.
+-type state() :: term().
+-type chunk_iterator() :: term().
+-type send_file_callback() ::
+    fun((osiris_log:header_map(), BytesToSend :: non_neg_integer()) ->
+        PrefixData :: binary()).
+
+%% Error type that means that an operation is temporarily unavailable and that
+%% retrying later is expected to eventually work.
+-type transient_error() :: unavailable.
+
+-export_type([options/0,
+              config/0,
+              state/0,
+              chunk_iterator/0,
+              send_file_callback/0,
+              transient_error/0]).
+
+-callback init_offset_reader(osiris:offset_spec(), config()) ->
+    {ok, state()} |
+    {error, transient_error() | term()}.
+-callback resolve_offset_spec(osiris:offset_spec(), config()) ->
+    {ok, osiris:offset()} |
+    {error, transient_error() | term()}.
+
+-callback next_offset(state()) -> osiris:offset().
+-callback committed_offset(state()) -> osiris:offset().
+-callback committed_chunk_id(state()) -> osiris:offset().
+-callback close(state()) -> ok.
+
+-callback send_file(gen_tcp:socket() | ssl:socket(), state(),
+                    send_file_callback()) ->
+    {ok, state()} |
+    {error, term()} |
+    {end_of_stream, state()}.
+
+-callback chunk_iterator(state(),
+                         Credit :: pos_integer() | all,
+                         PrevIter :: chunk_iterator() | undefined) ->
+    {ok, osiris_log:header_map(), chunk_iterator(), state()} |
+    {end_of_stream, state()} |
+    {error, term()}.
+
+-callback iterator_next(chunk_iterator()) ->
+    {{osiris:offset(), osiris:entry()}, chunk_iterator()} |
+    end_of_chunk.
+
+next_offset(State) ->
+    (module()):?FUNCTION_NAME(State).
+committed_offset(State) ->
+    (module()):?FUNCTION_NAME(State).
+committed_chunk_id(State) ->
+    (module()):?FUNCTION_NAME(State).
+close(State) ->
+    (module()):?FUNCTION_NAME(State).
+
+send_file(Socket, State) ->
+    send_file(Socket, State, fun(_, _) -> <<>> end).
+send_file(Socket, State0, Callback) ->
+    Mod = module(),
+    case Mod:?FUNCTION_NAME(Socket, State0, Callback) of
+        {offset_not_found, State1} when Mod =:= osiris_log ->
+            case osiris_log:open_next_segment(State1) of
+                {ok, State} ->
+                    send_file(Socket, State, Callback);
+                not_found ->
+                    {end_of_stream, State1}
+            end;
+        Other ->
+            Other
+    end.
+
+chunk_iterator(State, Credit) ->
+    chunk_iterator(State, Credit, undefined).
+chunk_iterator(State0, Credit, PrevChunkIterator) ->
+    Mod = module(),
+    case Mod:?FUNCTION_NAME(State0, Credit, PrevChunkIterator) of
+        {offset_not_found, State1} when Mod =:= osiris_log ->
+            case osiris_log:open_next_segment(State1) of
+                {ok, State} ->
+                    ?FUNCTION_NAME(State, Credit, undefined);
+                not_found ->
+                    {end_of_stream, State1}
+            end;
+        Other ->
+            Other
+    end.
+
+iterator_next(Iterator) ->
+    (module()):?FUNCTION_NAME(Iterator).
+
+%% @private
+module() ->
+    application:get_env(osiris, log_reader, osiris_log).

--- a/src/osiris_replica.erl
+++ b/src/osiris_replica.erl
@@ -598,21 +598,29 @@ handle_incoming_data(Socket, Bin,
     _ = setopts(Transport, Socket, [{active, 1}]),
     %% validate chunk
     {ParseState, OffsetChunks} = parse_chunk(Bin, ParseState0, []),
-    {OffsetTimestamp, Log} =
-        lists:foldl(fun({OffsetTs, B}, {_OffsTs, Acc0}) ->
-                       Acc = osiris_log:accept_chunk(B, Acc0),
-                       {OffsetTs, Acc}
+    try lists:foldl(fun({OffsetTs, B}, {_OffsTs, Acc0}) ->
+                            Acc = osiris_log:accept_chunk(B, Acc0),
+                            {OffsetTs, Acc}
                     end,
-                    {undefined, Log0}, OffsetChunks),
-    State1 = State0#?MODULE{log = Log, parse_state = ParseState},
-    case OffsetTimestamp of
-        undefined ->
-            {noreply, State1};
-        _ ->
-            TailInfo = osiris_log:tail_info(Log),
-            ok = osiris_writer:ack(LeaderPid, ack_msg(Cfg, TailInfo)),
-            State = notify_offset_listeners(State1),
-            {noreply, State}
+                    {undefined, Log0}, OffsetChunks) of
+        {OffsetTimestamp, Log} ->
+            State1 = State0#?MODULE{log = Log, parse_state = ParseState},
+            case OffsetTimestamp of
+                undefined ->
+                    {noreply, State1};
+                _ ->
+                    TailInfo = osiris_log:tail_info(Log),
+                    ok = osiris_writer:ack(LeaderPid, ack_msg(Cfg, TailInfo)),
+                    State = notify_offset_listeners(State1),
+                    {noreply, State}
+            end
+    catch
+        exit:{accept_chunk_out_of_order, Received, Expected} ->
+            ?WARN_(Cfg#cfg.name,
+                   "replica fell behind retention: received chunk at offset ~b "
+                   "but expected ~b, resyncing",
+                   [Received, Expected]),
+            {stop, normal, State0}
     end.
 
 %%--------------------------------------------------------------------

--- a/src/osiris_replica_reader.erl
+++ b/src/osiris_replica_reader.erl
@@ -346,6 +346,14 @@ do_sendfile0(#state{name = Name,
             _ = setopts(Transport, Sock, [{nopush, false}]),
             ?DEBUG_(Name, "sendfile err ~w", [_Err]),
             State;
+        {offset_not_found, Log1} ->
+            case osiris_log:open_next_segment(Log1) of
+                {ok, Log} ->
+                    do_sendfile0(State#state{log = Log});
+                not_found ->
+                    ok = setopts(Transport, Sock, [{nopush, false}]),
+                    State#state{log = Log1}
+            end;
         {end_of_stream, Log} ->
             _ = setopts(Transport, Sock, [{nopush, false}]),
             State#state{log = Log}

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -90,6 +90,7 @@ all_tests() ->
      evaluate_retention_max_bytes,
      evaluate_retention_max_age,
      evaluate_retention_max_age_empty,
+     evaluate_retention_fun,
      offset_tracking,
      offset_tracking_snapshot,
      many_segment_overview,
@@ -1728,6 +1729,37 @@ evaluate_retention_max_age(Config) ->
         filelib:wildcard(
             filename:join(LDir, "*.segment")),
     ?assertEqual(1, length(SegFiles)),
+    ?assertEqual([],
+                 lists:filter(fun(S) ->
+                                 lists:suffix("00000000000000000000.segment", S)
+                              end,
+                              SegFiles),
+                 "the retention process didn't delete the oldest segment"),
+    ok.
+
+evaluate_retention_fun(Config) ->
+    Data = crypto:strong_rand_bytes(1500),
+    EpochChunks =
+        [begin {1, [Data || _ <- lists:seq(1, 50)]} end
+         || _ <- lists:seq(1, 20)],
+    LDir = ?config(leader_dir, Config),
+    Log = seed_log(LDir, EpochChunks, Config),
+    osiris_log:close(Log),
+    %% delete only the first segment
+    Fun = fun(IdxFiles) ->
+                  lists:splitwith(fun(IdxFile) ->
+                                          filename:basename(IdxFile) =:=
+                                          <<"00000000000000000000.index">>
+                                  end, IdxFiles)
+          end,
+    Spec = {'fun', Fun},
+    Range = osiris_log:evaluate_retention(LDir, [Spec]),
+    %% idempotency check
+    Range = osiris_log:evaluate_retention(LDir, [Spec]),
+    SegFiles =
+        filelib:wildcard(
+            filename:join(LDir, "*.segment")),
+    ?assertMatch([_], SegFiles),
     ?assertEqual([],
                  lists:filter(fun(S) ->
                                  lists:suffix("00000000000000000000.segment", S)

--- a/test/osiris_log_SUITE.erl
+++ b/test/osiris_log_SUITE.erl
@@ -697,6 +697,7 @@ write_multi_log(Config) ->
     OffRef = osiris_log:get_shared(S1),
     %% takes a single offset tracking data into account
     osiris_log_shared:set_committed_chunk_id(OffRef, NextOffset),
+    osiris_log_shared:set_last_chunk_id(OffRef, NextOffset - 10),
     %% ensure all records can be read
     {ok, R0} =
         osiris_log:init_offset_reader(first, Conf#{shared => OffRef}),


### PR DESCRIPTION
This is a recreation of #196 - some git nonsense lead to the PR there auto-closing.

This is is three changes:

* Introduction of a `{'fun', fun()}` retention spec which lets retention policies have fine-grained control over what prefix of the osiris_log is deleted.
* `osiris_log_reader` behaviour and module. Consumers of Osiris use the `osiris` API to create an offset reader and then `osiris_log_reader` to use the reader. The default implementation uses osiris_log as usual.
* `osiris_log_hooks` behaviour and default (empty) implementation. Implementors can use this to hook into the lifecycles of Osiris around writer and acceptor creation, and retention updates. This one is super small.

Together these things make a solid base for implementing #184 (fixes #184). We use it in https://github.com/amazon-mq/rabbitmq-stream-s3 to serve a tiered-storage approach that aggressively archives data to elastic blob storage (Amazon S3) which appears seemless from the outside. It should be generic to other approaches (e.g. other blob stores or HDFS, or maybe even offload to shared spinning disks / RAID).

See a bunch of prior history in #196 and #194 before that.